### PR TITLE
Add better powershell highlighting

### DIFF
--- a/code-examples/.psm1
+++ b/code-examples/.psm1
@@ -1,0 +1,26 @@
+Param(
+	[Parameter(Mandatory=$True)]
+	[string]
+	$WorkingFolder
+)
+
+$powershellScripts = Get-ChildItem -Path "$WorkingFolder" -Filter "*.ps1" -Exclude "*.tests.*" -Recurse -File
+
+Function Test-PowershellScript {
+  Param(
+    [string]$FilePath
+  )
+
+  It "is a valid Powershell Code" {
+    $psFile = Get-Content -Path $FilePath -ErrorAction Stop
+    $errors = $null
+    $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
+    $errors.Count | Should -Be 0
+  }
+}
+
+ForEach ($powershellScript In $powershellScripts) {
+  Describe $powershellScript.FullName.Replace($WorkingFolder, "") {
+    Test-PowershellScript -FilePath $powershellScript.FullName
+  }
+}

--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -859,6 +859,37 @@
       "settings": {
         "foreground": "#fe8019"
       }
+    },
+    // POWERSHELL ------------------------------------
+    {
+      "name": "Powershell member",
+      "scope": ["source.powershell variable.other.member.powershell"],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "name": "Powershell function",
+      "scope": ["source.powershell support.function.powershell"],
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "name": "Powershell function attribute",
+      "scope": ["source.powershell support.function.attribute.powershell"],
+      "settings": {
+        "foreground": "#bdae93"
+      }
+    },
+    {
+      "name": "Powershell hashtable member",
+      "scope": [
+        "source.powershell meta.hashtable.assignment.powershell variable.other.readwrite.powershell"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
     }
   ],
   "colors": {

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -859,6 +859,37 @@
       "settings": {
         "foreground": "#fe8019"
       }
+    },
+    // POWERSHELL ------------------------------------
+    {
+      "name": "Powershell member",
+      "scope": ["source.powershell variable.other.member.powershell"],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "name": "Powershell function",
+      "scope": ["source.powershell support.function.powershell"],
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "name": "Powershell function attribute",
+      "scope": ["source.powershell support.function.attribute.powershell"],
+      "settings": {
+        "foreground": "#bdae93"
+      }
+    },
+    {
+      "name": "Powershell hashtable member",
+      "scope": [
+        "source.powershell meta.hashtable.assignment.powershell variable.other.readwrite.powershell"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
     }
   ],
   "colors": {

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -1,5 +1,5 @@
 {
-  "name": "Gruvbox Dark Medium",
+  "name": "Gruvbox Dark Soft",
   "type": "dark",
   "tokenColors": [
     {
@@ -855,6 +855,37 @@
       "scope": [
         "source.reason support.property-value",
         "source.reason entity.name.filename"
+      ],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    // POWERSHELL ------------------------------------
+    {
+      "name": "Powershell member",
+      "scope": ["source.powershell variable.other.member.powershell"],
+      "settings": {
+        "foreground": "#fe8019"
+      }
+    },
+    {
+      "name": "Powershell function",
+      "scope": ["source.powershell support.function.powershell"],
+      "settings": {
+        "foreground": "#fabd2f"
+      }
+    },
+    {
+      "name": "Powershell function attribute",
+      "scope": ["source.powershell support.function.attribute.powershell"],
+      "settings": {
+        "foreground": "#bdae93"
+      }
+    },
+    {
+      "name": "Powershell hashtable member",
+      "scope": [
+        "source.powershell meta.hashtable.assignment.powershell variable.other.readwrite.powershell"
       ],
       "settings": {
         "foreground": "#fe8019"

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -1,5 +1,5 @@
 {
-  "name": "Gruvbox Light Medium",
+  "name": "Gruvbox Light Hard",
   "tokenColors": [
     {
       "settings": {
@@ -854,6 +854,37 @@
       "scope": [
         "source.reason support.property-value",
         "source.reason entity.name.filename"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    // POWERSHELL ------------------------------------
+    {
+      "name": "Powershell member",
+      "scope": ["source.powershell variable.other.member.powershell"],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "name": "Powershell function",
+      "scope": ["source.powershell support.function.powershell"],
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "name": "Powershell function attribute",
+      "scope": ["source.powershell support.function.attribute.powershell"],
+      "settings": {
+        "foreground": "#665c54"
+      }
+    },
+    {
+      "name": "Powershell hashtable member",
+      "scope": [
+        "source.powershell meta.hashtable.assignment.powershell variable.other.readwrite.powershell"
       ],
       "settings": {
         "foreground": "#af3a03"

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -858,6 +858,37 @@
       "settings": {
         "foreground": "#af3a03"
       }
+    },
+    // POWERSHELL ------------------------------------
+    {
+      "name": "Powershell member",
+      "scope": ["source.powershell variable.other.member.powershell"],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "name": "Powershell function",
+      "scope": ["source.powershell support.function.powershell"],
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "name": "Powershell function attribute",
+      "scope": ["source.powershell support.function.attribute.powershell"],
+      "settings": {
+        "foreground": "#665c54"
+      }
+    },
+    {
+      "name": "Powershell hashtable member",
+      "scope": [
+        "source.powershell meta.hashtable.assignment.powershell variable.other.readwrite.powershell"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
     }
   ],
   "colors": {

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -1,5 +1,5 @@
 {
-  "name": "Gruvbox Light Medium",
+  "name": "Gruvbox Light Soft",
   "tokenColors": [
     {
       "settings": {
@@ -854,6 +854,37 @@
       "scope": [
         "source.reason support.property-value",
         "source.reason entity.name.filename"
+      ],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    // POWERSHELL ------------------------------------
+    {
+      "name": "Powershell member",
+      "scope": ["source.powershell variable.other.member.powershell"],
+      "settings": {
+        "foreground": "#af3a03"
+      }
+    },
+    {
+      "name": "Powershell function",
+      "scope": ["source.powershell support.function.powershell"],
+      "settings": {
+        "foreground": "#b57614"
+      }
+    },
+    {
+      "name": "Powershell function attribute",
+      "scope": ["source.powershell support.function.attribute.powershell"],
+      "settings": {
+        "foreground": "#665c54"
+      }
+    },
+    {
+      "name": "Powershell hashtable member",
+      "scope": [
+        "source.powershell meta.hashtable.assignment.powershell variable.other.readwrite.powershell"
       ],
       "settings": {
         "foreground": "#af3a03"


### PR DESCRIPTION
Before:
![captureb](https://user-images.githubusercontent.com/3809868/49016446-09f49f80-f17e-11e8-9c66-f6caf5983cd1.PNG)

After:
![capturea](https://user-images.githubusercontent.com/3809868/49016452-0bbe6300-f17e-11e8-91e4-7f05f2de97c6.PNG)

Ideally this would also highlight cmdlet parameters in grey or something, but the grammar doesn't expose it