### PR TITLE
fixed tab bar selectors

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -957,9 +957,9 @@
     "editorGroup.background": "#3c3836",
     "editorGroup.border": "#3c3836",
     "editorGroup.dropBackground": "#3c383660",
-    "editorGroup.noTabsBackground": "#3c3836",
-    "editorGroup.tabsbackground": "#3c3836",
-    "editorGroup.tabsBorder": "#3c383600",
+    "editorGroupHeader.noTabsBackground": "#3c3836",
+    "editorGroupHeader.tabsBackground": "#3c3836",
+    "editorGroupHeader.tabsBorder": "#3c383600",
     // TABS
     "tab.border": "#1d202100",
     "tab.activeBorder": "#1d2021",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -957,9 +957,9 @@
     "editorGroup.background": "#3c3836",
     "editorGroup.border": "#3c3836",
     "editorGroup.dropBackground": "#3c383660",
-    "editorGroup.noTabsBackground": "#3c3836",
-    "editorGroup.tabsbackground": "#3c3836",
-    "editorGroup.tabsBorder": "#3c383600",
+    "editorGroupHeader.noTabsBackground": "#3c3836",
+    "editorGroupHeader.tabsBackground": "#3c3836",
+    "editorGroupHeader.tabsBorder": "#3c383600",
     // TABS
     "tab.border": "#28282800",
     "tab.activeBorder": "#282828",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -957,9 +957,9 @@
     "editorGroup.background": "#3c3836",
     "editorGroup.border": "#3c3836",
     "editorGroup.dropBackground": "#3c383660",
-    "editorGroup.noTabsBackground": "#3c3836",
-    "editorGroup.tabsbackground": "#3c3836",
-    "editorGroup.tabsBorder": "#3c383600",
+    "editorGroupHeader.noTabsBackground": "#3c3836",
+    "editorGroupHeader.tabsBackground": "#3c3836",
+    "editorGroupHeader.tabsBorder": "#3c383600",
     // TABS
     "tab.border": "#32302f00",
     "tab.activeBorder": "#32302f",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -956,9 +956,9 @@
     "editorGroup.background": "#ebdbb2",
     "editorGroup.border": "#ebdbb2",
     "editorGroup.dropBackground": "#ebdbb260",
-    "editorGroup.noTabsBackground": "#ebdbb2",
-    "editorGroup.tabsbackground": "#ebdbb2",
-    "editorGroup.tabsBorder": "#ebdbb200",
+    "editorGroupHeader.noTabsBackground": "#ebdbb2",
+    "editorGroupHeader.tabsBackground": "#ebdbb2",
+    "editorGroupHeader.tabsBorder": "#ebdbb200",
     // TABS
     "tab.border": "#f9f5d700",
     "tab.activeBorder": "#f9f5d7",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -956,9 +956,9 @@
     "editorGroup.background": "#ebdbb2",
     "editorGroup.border": "#ebdbb2",
     "editorGroup.dropBackground": "#ebdbb260",
-    "editorGroup.noTabsBackground": "#ebdbb2",
-    "editorGroup.tabsbackground": "#ebdbb2",
-    "editorGroup.tabsBorder": "#ebdbb200",
+    "editorGroupHeader.noTabsBackground": "#ebdbb2",
+    "editorGroupHeader.tabsBackground": "#ebdbb2",
+    "editorGroupHeader.tabsBorder": "#ebdbb200",
     // TABS
     "tab.border": "#fbf1c700",
     "tab.activeBorder": "#fbf1c7",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -956,9 +956,9 @@
     "editorGroup.background": "#ebdbb2",
     "editorGroup.border": "#ebdbb2",
     "editorGroup.dropBackground": "#ebdbb260",
-    "editorGroup.noTabsBackground": "#ebdbb2",
-    "editorGroup.tabsbackground": "#ebdbb2",
-    "editorGroup.tabsBorder": "#ebdbb200",
+    "editorGroupHeader.noTabsBackground": "#ebdbb2",
+    "editorGroupHeader.tabsBackground": "#ebdbb2",
+    "editorGroupHeader.tabsBorder": "#ebdbb200",
     // TABS
     "tab.border": "#f2e5bc00",
     "tab.activeBorder": "#f2e5bc",


### PR DESCRIPTION
I noticed the tab bar background being off, and after going through the extension files I figured it's probably not intentional, but caused by a wrong selector. This is not as visible with the dark variant as it's dark-gray vs the default black, but with the light theme the default white really sticks out. It's even visible in the screenshots that the rightmost portion of the tab bar has wrong color.