### PR TITLE
Remove text borders in diff editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Special thank to [Pavel Pertsev](https://github.com/morhetz), the creator of [gr
 -   [Layo](https://github.com/layoaster)
 -   [Maxim Tsoy](https://github.com/muodov)
 -   [Huip van den Ende](https://github.com/huipvandenende)
+-   [Christian Klaussner](https://github.com/klaussner)
 
 Thanks for help to make the Gruvbox theme better.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "sedmicha (https://github.com/sedmicha)",
     "Layo (https://github.com/layoaster)",
     "Maxim Tsoy (https://github.com/muodov)",
-    "Huip van den Ende (https://github.com/huipvandenende)"
+    "Huip van den Ende (https://github.com/huipvandenende)",
+    "Christian Klaussner (https://github.com/klaussner)"
   ],
   "publisher": "jdinhlife",
   "engines": {

--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -1064,9 +1064,7 @@
     "editorInfo.foreground": "#458588",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
-    "diffEditor.insertedTextBorder": "#98971a00",
     "diffEditor.removedTextBackground": "#fb493430",
-    "diffEditor.removedTextBorder": "#cc241d00",
     // WIDGET
     "editorWidget.background": "#1d2021",
     "editorWidget.border": "#3c3836",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -1064,9 +1064,7 @@
     "editorInfo.foreground": "#458588",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
-    "diffEditor.insertedTextBorder": "#98971a00",
     "diffEditor.removedTextBackground": "#fb493430",
-    "diffEditor.removedTextBorder": "#cc241d00",
     // WIDGET
     "editorWidget.background": "#282828",
     "editorWidget.border": "#3c3836",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -1064,9 +1064,7 @@
     "editorInfo.foreground": "#458588",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
-    "diffEditor.insertedTextBorder": "#98971a00",
     "diffEditor.removedTextBackground": "#fb493430",
-    "diffEditor.removedTextBorder": "#cc241d00",
     // WIDGET
     "editorWidget.background": "#32302f",
     "editorWidget.border": "#3c3836",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -1063,9 +1063,7 @@
     "editorInfo.foreground": "#458588",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
-    "diffEditor.insertedTextBorder": "#98971a00",
     "diffEditor.removedTextBackground": "#9d000630",
-    "diffEditor.removedTextBorder": "#cc241d00",
     // WIDGET
     "editorWidget.background": "#f9f5d7",
     "editorWidget.border": "#ebdbb2",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -1063,9 +1063,7 @@
     "editorInfo.foreground": "#458588",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
-    "diffEditor.insertedTextBorder": "#98971a00",
     "diffEditor.removedTextBackground": "#9d000630",
-    "diffEditor.removedTextBorder": "#cc241d00",
     // WIDGET
     "editorWidget.background": "#fbf1c7",
     "editorWidget.border": "#ebdbb2",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -1063,9 +1063,7 @@
     "editorInfo.foreground": "#458588",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
-    "diffEditor.insertedTextBorder": "#98971a00",
     "diffEditor.removedTextBackground": "#9d000630",
-    "diffEditor.removedTextBorder": "#cc241d00",
     // WIDGET
     "editorWidget.background": "#f2e5bc",
     "editorWidget.border": "#ebdbb2",


### PR DESCRIPTION
Setting the `diffEditor.insertedTextBorder` and `diffEditor.removedTextBorder` colors offsets changed lines in the diff editor by a few pixels. Since the colors have an alpha value of zero and aren't visible anyway, this PR removes them from all theme files.

Before:
![gruvbox-issue](https://user-images.githubusercontent.com/1312807/132089699-2da7c9a8-bd3d-4758-abae-e89733003729.png)

After:
![gruvbox-fixed](https://user-images.githubusercontent.com/1312807/132089701-0acd9a04-fb37-44ae-9877-c3c131ae2b6c.png)

Fixes #34.