### PR TITLE
Bracket pair colorisation proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Special thank to [Pavel Pertsev](https://github.com/morhetz), the creator of [gr
 -   [Maxim Tsoy](https://github.com/muodov)
 -   [Huip van den Ende](https://github.com/huipvandenende)
 -   [Christian Klaussner](https://github.com/klaussner)
+-   [Anton Shpigunov](https://github.com/shpigunov)
 
 Thanks for help to make the Gruvbox theme better.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "Layo (https://github.com/layoaster)",
     "Maxim Tsoy (https://github.com/muodov)",
     "Huip van den Ende (https://github.com/huipvandenende)",
-    "Christian Klaussner (https://github.com/klaussner)"
+    "Christian Klaussner (https://github.com/klaussner)",
+    "Anton Shpigunov (https://github.com/shpigunov)"
   ],
   "publisher": "jdinhlife",
   "engines": {

--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -1062,6 +1062,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - BRACKET PAIR COLORIZATION
+    "editorBracketHighlight.foreground1": "#b16286",
+    "editorBracketHighlight.foreground2": "#458588",
+    "editorBracketHighlight.foreground3": "#98971a",
+    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground6": "#d65d0e",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",

--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -991,8 +991,9 @@
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",
-    "editorBracketHighlight.foreground3": "#98971a",
-    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground3": "#689d6a",
+    "editorBracketHighlight.foreground4": "#98971a",
+    "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR

--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -27,21 +27,14 @@
       }
     },
     {
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "foreground": "#928374",
         "fontStyle": "italic"
       }
     },
     {
-      "scope": [
-        "constant",
-        "support.constant",
-        "variable.arguments"
-      ],
+      "scope": ["constant", "support.constant", "variable.arguments"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -65,19 +58,13 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag",
-        "punctuation.tag"
-      ],
+      "scope": ["entity.name.tag", "punctuation.tag"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
-      "scope": [
-        "invalid",
-        "invalid.illegal"
-      ],
+      "scope": ["invalid", "invalid.illegal"],
       "settings": {
         "foreground": "#cc241d"
       }
@@ -267,10 +254,7 @@
       }
     },
     {
-      "scope": [
-        "variable.this",
-        "support.variable"
-      ],
+      "scope": ["variable.this", "support.variable"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -354,9 +338,7 @@
       }
     },
     {
-      "scope": [
-        "punctuation"
-      ],
+      "scope": ["punctuation"],
       "settings": {
         "foreground": "#a89984"
       }
@@ -375,11 +357,7 @@
     },
     {
       "name": "URL",
-      "scope": [
-        "*url*",
-        "*link*",
-        "*uri*"
-      ],
+      "scope": ["*url*", "*link*", "*uri*"],
       "settings": {
         "fontStyle": "underline"
       }
@@ -390,10 +368,7 @@
     // PYTHON ----------------------------------------
     {
       "name": "Python function",
-      "scope": [
-        "meta.function.python",
-        "entity.name.function.python"
-      ],
+      "scope": ["meta.function.python", "entity.name.function.python"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -505,10 +480,7 @@
     },
     {
       "name": "C# This",
-      "scope": [
-        "keyword.other.this.cs",
-        "keyword.other.base.cs"
-      ],
+      "scope": ["keyword.other.this.cs", "keyword.other.base.cs"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -539,10 +511,7 @@
       }
     },
     {
-      "scope": [
-        "keyword.other.import.java",
-        "keyword.other.package.java"
-      ],
+      "scope": ["keyword.other.import.java", "keyword.other.package.java"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -661,10 +630,7 @@
       }
     },
     {
-      "scope": [
-        "markup.inline.raw",
-        "markup.fenced_code.block"
-      ],
+      "scope": ["markup.inline.raw", "markup.fenced_code.block"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -760,27 +726,20 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag.css"
-      ],
+      "scope": ["entity.name.tag.css"],
       "settings": {
         "fontStyle": "normal"
       }
     },
     // HTML / XML ----------------------------------------
     {
-      "scope": [
-        "punctuation.definition.tag"
-      ],
+      "scope": ["punctuation.definition.tag"],
       "settings": {
         "foreground": "#83a598"
       }
     },
     {
-      "scope": [
-        "text.html entity.name.tag",
-        "text.html punctuation.tag"
-      ],
+      "scope": ["text.html entity.name.tag", "text.html punctuation.tag"],
       "settings": {
         "foreground": "#8ec07c",
         "fontStyle": "bold"
@@ -788,78 +747,58 @@
     },
     // javascript ---------------------------------------
     {
-      "scope": [
-        "source.js variable.language"
-      ],
+      "scope": ["source.js variable.language"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     // typescript ---------------------------------------
     {
-      "scope": [
-        "source.ts variable.language"
-      ],
+      "scope": ["source.ts variable.language"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     // golang --------------------------------------------
     {
-      "scope": [
-        "source.go storage.type"
-      ],
+      "scope": ["source.go storage.type"],
       "settings": {
         "foreground": "#fabd2f"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.import"
-      ],
+      "scope": ["source.go entity.name.import"],
       "settings": {
         "foreground": "#b8bb26"
       }
     },
     {
-      "scope": [
-        "source.go keyword.package",
-        "source.go keyword.import"
-      ],
+      "scope": ["source.go keyword.package", "source.go keyword.import"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
-      "scope": [
-        "source.go keyword.interface",
-        "source.go keyword.struct"
-      ],
+      "scope": ["source.go keyword.interface", "source.go keyword.struct"],
       "settings": {
         "foreground": "#83a598"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.type"
-      ],
+      "scope": ["source.go entity.name.type"],
       "settings": {
         "foreground": "#ebdbb2"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.function"
-      ],
+      "scope": ["source.go entity.name.function"],
       "settings": {
         "foreground": "#d3869b"
       }
     },
     // cucumber
     {
-      "scope": [
-        "keyword.control.cucumber.table"
-      ],
+      "scope": ["keyword.control.cucumber.table"],
       "settings": {
         "foreground": "#83a598"
       }
@@ -867,28 +806,21 @@
     // REASONML ------------------------------------
     {
       "name": "ReasonML String",
-      "scope": [
-        "source.reason string.double",
-        "source.reason string.regexp"
-      ],
+      "scope": ["source.reason string.double", "source.reason string.regexp"],
       "settings": {
         "foreground": "#b8bb26"
       }
     },
     {
       "name": "ReasonML equals sign",
-      "scope": [
-        "source.reason keyword.control.less"
-      ],
+      "scope": ["source.reason keyword.control.less"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
       "name": "ReasonML variable",
-      "scope": [
-        "source.reason entity.name.function"
-      ],
+      "scope": ["source.reason entity.name.function"],
       "settings": {
         "foreground": "#83a598"
       }
@@ -906,27 +838,21 @@
     // POWERSHELL ------------------------------------
     {
       "name": "Powershell member",
-      "scope": [
-        "source.powershell variable.other.member.powershell"
-      ],
+      "scope": ["source.powershell variable.other.member.powershell"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     {
       "name": "Powershell function",
-      "scope": [
-        "source.powershell support.function.powershell"
-      ],
+      "scope": ["source.powershell support.function.powershell"],
       "settings": {
         "foreground": "#fabd2f"
       }
     },
     {
       "name": "Powershell function attribute",
-      "scope": [
-        "source.powershell support.function.attribute.powershell"
-      ],
+      "scope": ["source.powershell support.function.attribute.powershell"],
       "settings": {
         "foreground": "#bdae93"
       }
@@ -1068,7 +994,7 @@
     "editorBracketHighlight.foreground3": "#98971a",
     "editorBracketHighlight.foreground4": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
-    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -994,7 +994,7 @@
     "editorBracketHighlight.foreground3": "#98971a",
     "editorBracketHighlight.foreground4": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
-    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",
@@ -1089,6 +1089,6 @@
     // OTHERS
     "textLink.foreground": "#83a598",
     "textLink.activeForeground": "#458588",
-    "debugToolBar.background": "#282828",
+    "debugToolBar.background": "#282828"
   }
 }

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -27,21 +27,14 @@
       }
     },
     {
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "foreground": "#928374",
         "fontStyle": "italic"
       }
     },
     {
-      "scope": [
-        "constant",
-        "support.constant",
-        "variable.arguments"
-      ],
+      "scope": ["constant", "support.constant", "variable.arguments"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -65,19 +58,13 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag",
-        "punctuation.tag"
-      ],
+      "scope": ["entity.name.tag", "punctuation.tag"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
-      "scope": [
-        "invalid",
-        "invalid.illegal"
-      ],
+      "scope": ["invalid", "invalid.illegal"],
       "settings": {
         "foreground": "#cc241d"
       }
@@ -267,10 +254,7 @@
       }
     },
     {
-      "scope": [
-        "variable.this",
-        "support.variable"
-      ],
+      "scope": ["variable.this", "support.variable"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -354,9 +338,7 @@
       }
     },
     {
-      "scope": [
-        "punctuation"
-      ],
+      "scope": ["punctuation"],
       "settings": {
         "foreground": "#a89984"
       }
@@ -375,11 +357,7 @@
     },
     {
       "name": "URL",
-      "scope": [
-        "*url*",
-        "*link*",
-        "*uri*"
-      ],
+      "scope": ["*url*", "*link*", "*uri*"],
       "settings": {
         "fontStyle": "underline"
       }
@@ -390,10 +368,7 @@
     // PYTHON ----------------------------------------
     {
       "name": "Python function",
-      "scope": [
-        "meta.function.python",
-        "entity.name.function.python"
-      ],
+      "scope": ["meta.function.python", "entity.name.function.python"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -505,10 +480,7 @@
     },
     {
       "name": "C# This",
-      "scope": [
-        "keyword.other.this.cs",
-        "keyword.other.base.cs"
-      ],
+      "scope": ["keyword.other.this.cs", "keyword.other.base.cs"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -539,10 +511,7 @@
       }
     },
     {
-      "scope": [
-        "keyword.other.import.java",
-        "keyword.other.package.java"
-      ],
+      "scope": ["keyword.other.import.java", "keyword.other.package.java"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -661,10 +630,7 @@
       }
     },
     {
-      "scope": [
-        "markup.inline.raw",
-        "markup.fenced_code.block"
-      ],
+      "scope": ["markup.inline.raw", "markup.fenced_code.block"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -760,27 +726,20 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag.css"
-      ],
+      "scope": ["entity.name.tag.css"],
       "settings": {
         "fontStyle": "normal"
       }
     },
     // HTML / XML ----------------------------------------
     {
-      "scope": [
-        "punctuation.definition.tag"
-      ],
+      "scope": ["punctuation.definition.tag"],
       "settings": {
         "foreground": "#83a598"
       }
     },
     {
-      "scope": [
-        "text.html entity.name.tag",
-        "text.html punctuation.tag"
-      ],
+      "scope": ["text.html entity.name.tag", "text.html punctuation.tag"],
       "settings": {
         "foreground": "#8ec07c",
         "fontStyle": "bold"
@@ -788,78 +747,58 @@
     },
     // javascript ---------------------------------------
     {
-      "scope": [
-        "source.js variable.language"
-      ],
+      "scope": ["source.js variable.language"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     // typescript ---------------------------------------
     {
-      "scope": [
-        "source.ts variable.language"
-      ],
+      "scope": ["source.ts variable.language"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     // golang --------------------------------------------
     {
-      "scope": [
-        "source.go storage.type"
-      ],
+      "scope": ["source.go storage.type"],
       "settings": {
         "foreground": "#fabd2f"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.import"
-      ],
+      "scope": ["source.go entity.name.import"],
       "settings": {
         "foreground": "#b8bb26"
       }
     },
     {
-      "scope": [
-        "source.go keyword.package",
-        "source.go keyword.import"
-      ],
+      "scope": ["source.go keyword.package", "source.go keyword.import"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
-      "scope": [
-        "source.go keyword.interface",
-        "source.go keyword.struct"
-      ],
+      "scope": ["source.go keyword.interface", "source.go keyword.struct"],
       "settings": {
         "foreground": "#83a598"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.type"
-      ],
+      "scope": ["source.go entity.name.type"],
       "settings": {
         "foreground": "#ebdbb2"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.function"
-      ],
+      "scope": ["source.go entity.name.function"],
       "settings": {
         "foreground": "#d3869b"
       }
     },
     // cucumber
     {
-      "scope": [
-        "keyword.control.cucumber.table"
-      ],
+      "scope": ["keyword.control.cucumber.table"],
       "settings": {
         "foreground": "#83a598"
       }
@@ -867,28 +806,21 @@
     // REASONML ------------------------------------
     {
       "name": "ReasonML String",
-      "scope": [
-        "source.reason string.double",
-        "source.reason string.regexp"
-      ],
+      "scope": ["source.reason string.double", "source.reason string.regexp"],
       "settings": {
         "foreground": "#b8bb26"
       }
     },
     {
       "name": "ReasonML equals sign",
-      "scope": [
-        "source.reason keyword.control.less"
-      ],
+      "scope": ["source.reason keyword.control.less"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
       "name": "ReasonML variable",
-      "scope": [
-        "source.reason entity.name.function"
-      ],
+      "scope": ["source.reason entity.name.function"],
       "settings": {
         "foreground": "#83a598"
       }
@@ -906,27 +838,21 @@
     // POWERSHELL ------------------------------------
     {
       "name": "Powershell member",
-      "scope": [
-        "source.powershell variable.other.member.powershell"
-      ],
+      "scope": ["source.powershell variable.other.member.powershell"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     {
       "name": "Powershell function",
-      "scope": [
-        "source.powershell support.function.powershell"
-      ],
+      "scope": ["source.powershell support.function.powershell"],
       "settings": {
         "foreground": "#fabd2f"
       }
     },
     {
       "name": "Powershell function attribute",
-      "scope": [
-        "source.powershell support.function.attribute.powershell"
-      ],
+      "scope": ["source.powershell support.function.attribute.powershell"],
       "settings": {
         "foreground": "#bdae93"
       }
@@ -1062,6 +988,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - BRACKET PAIR COLORIZATION
+    "editorBracketHighlight.foreground1": "#b16286",
+    "editorBracketHighlight.foreground2": "#458588",
+    "editorBracketHighlight.foreground3": "#98971a",
+    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground6": "#d65d0e",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",
@@ -1156,6 +1089,6 @@
     // OTHERS
     "textLink.foreground": "#83a598",
     "textLink.activeForeground": "#458588",
-    "debugToolBar.background": "#282828"
+    "debugToolBar.background": "#282828",
   }
 }

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -991,8 +991,9 @@
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",
-    "editorBracketHighlight.foreground3": "#98971a",
-    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground3": "#689d6a",
+    "editorBracketHighlight.foreground4": "#98971a",
+    "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -1062,6 +1062,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - BRACKET PAIR COLORIZATION
+    "editorBracketHighlight.foreground1": "#b16286",
+    "editorBracketHighlight.foreground2": "#458588",
+    "editorBracketHighlight.foreground3": "#98971a",
+    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground6": "#d65d0e",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -991,8 +991,9 @@
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",
-    "editorBracketHighlight.foreground3": "#98971a",
-    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground3": "#689d6a",
+    "editorBracketHighlight.foreground4": "#98971a",
+    "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -27,21 +27,14 @@
       }
     },
     {
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "foreground": "#928374",
         "fontStyle": "italic"
       }
     },
     {
-      "scope": [
-        "constant",
-        "support.constant",
-        "variable.arguments"
-      ],
+      "scope": ["constant", "support.constant", "variable.arguments"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -65,19 +58,13 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag",
-        "punctuation.tag"
-      ],
+      "scope": ["entity.name.tag", "punctuation.tag"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
-      "scope": [
-        "invalid",
-        "invalid.illegal"
-      ],
+      "scope": ["invalid", "invalid.illegal"],
       "settings": {
         "foreground": "#cc241d"
       }
@@ -267,10 +254,7 @@
       }
     },
     {
-      "scope": [
-        "variable.this",
-        "support.variable"
-      ],
+      "scope": ["variable.this", "support.variable"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -354,9 +338,7 @@
       }
     },
     {
-      "scope": [
-        "punctuation"
-      ],
+      "scope": ["punctuation"],
       "settings": {
         "foreground": "#a89984"
       }
@@ -375,11 +357,7 @@
     },
     {
       "name": "URL",
-      "scope": [
-        "*url*",
-        "*link*",
-        "*uri*"
-      ],
+      "scope": ["*url*", "*link*", "*uri*"],
       "settings": {
         "fontStyle": "underline"
       }
@@ -390,10 +368,7 @@
     // PYTHON ----------------------------------------
     {
       "name": "Python function",
-      "scope": [
-        "meta.function.python",
-        "entity.name.function.python"
-      ],
+      "scope": ["meta.function.python", "entity.name.function.python"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -505,10 +480,7 @@
     },
     {
       "name": "C# This",
-      "scope": [
-        "keyword.other.this.cs",
-        "keyword.other.base.cs"
-      ],
+      "scope": ["keyword.other.this.cs", "keyword.other.base.cs"],
       "settings": {
         "foreground": "#d3869b"
       }
@@ -539,10 +511,7 @@
       }
     },
     {
-      "scope": [
-        "keyword.other.import.java",
-        "keyword.other.package.java"
-      ],
+      "scope": ["keyword.other.import.java", "keyword.other.package.java"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -661,10 +630,7 @@
       }
     },
     {
-      "scope": [
-        "markup.inline.raw",
-        "markup.fenced_code.block"
-      ],
+      "scope": ["markup.inline.raw", "markup.fenced_code.block"],
       "settings": {
         "foreground": "#8ec07c"
       }
@@ -760,27 +726,20 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag.css"
-      ],
+      "scope": ["entity.name.tag.css"],
       "settings": {
         "fontStyle": "normal"
       }
     },
     // HTML / XML ----------------------------------------
     {
-      "scope": [
-        "punctuation.definition.tag"
-      ],
+      "scope": ["punctuation.definition.tag"],
       "settings": {
         "foreground": "#83a598"
       }
     },
     {
-      "scope": [
-        "text.html entity.name.tag",
-        "text.html punctuation.tag"
-      ],
+      "scope": ["text.html entity.name.tag", "text.html punctuation.tag"],
       "settings": {
         "foreground": "#8ec07c",
         "fontStyle": "bold"
@@ -788,78 +747,58 @@
     },
     // javascript ---------------------------------------
     {
-      "scope": [
-        "source.js variable.language"
-      ],
+      "scope": ["source.js variable.language"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     // typescript ---------------------------------------
     {
-      "scope": [
-        "source.ts variable.language"
-      ],
+      "scope": ["source.ts variable.language"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     // golang --------------------------------------------
     {
-      "scope": [
-        "source.go storage.type"
-      ],
+      "scope": ["source.go storage.type"],
       "settings": {
         "foreground": "#fabd2f"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.import"
-      ],
+      "scope": ["source.go entity.name.import"],
       "settings": {
         "foreground": "#b8bb26"
       }
     },
     {
-      "scope": [
-        "source.go keyword.package",
-        "source.go keyword.import"
-      ],
+      "scope": ["source.go keyword.package", "source.go keyword.import"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
-      "scope": [
-        "source.go keyword.interface",
-        "source.go keyword.struct"
-      ],
+      "scope": ["source.go keyword.interface", "source.go keyword.struct"],
       "settings": {
         "foreground": "#83a598"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.type"
-      ],
+      "scope": ["source.go entity.name.type"],
       "settings": {
         "foreground": "#ebdbb2"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.function"
-      ],
+      "scope": ["source.go entity.name.function"],
       "settings": {
         "foreground": "#d3869b"
       }
     },
     // cucumber
     {
-      "scope": [
-        "keyword.control.cucumber.table"
-      ],
+      "scope": ["keyword.control.cucumber.table"],
       "settings": {
         "foreground": "#83a598"
       }
@@ -867,28 +806,21 @@
     // REASONML ------------------------------------
     {
       "name": "ReasonML String",
-      "scope": [
-        "source.reason string.double",
-        "source.reason string.regexp"
-      ],
+      "scope": ["source.reason string.double", "source.reason string.regexp"],
       "settings": {
         "foreground": "#b8bb26"
       }
     },
     {
       "name": "ReasonML equals sign",
-      "scope": [
-        "source.reason keyword.control.less"
-      ],
+      "scope": ["source.reason keyword.control.less"],
       "settings": {
         "foreground": "#8ec07c"
       }
     },
     {
       "name": "ReasonML variable",
-      "scope": [
-        "source.reason entity.name.function"
-      ],
+      "scope": ["source.reason entity.name.function"],
       "settings": {
         "foreground": "#83a598"
       }
@@ -906,27 +838,21 @@
     // POWERSHELL ------------------------------------
     {
       "name": "Powershell member",
-      "scope": [
-        "source.powershell variable.other.member.powershell"
-      ],
+      "scope": ["source.powershell variable.other.member.powershell"],
       "settings": {
         "foreground": "#fe8019"
       }
     },
     {
       "name": "Powershell function",
-      "scope": [
-        "source.powershell support.function.powershell"
-      ],
+      "scope": ["source.powershell support.function.powershell"],
       "settings": {
         "foreground": "#fabd2f"
       }
     },
     {
       "name": "Powershell function attribute",
-      "scope": [
-        "source.powershell support.function.attribute.powershell"
-      ],
+      "scope": ["source.powershell support.function.attribute.powershell"],
       "settings": {
         "foreground": "#bdae93"
       }
@@ -1068,7 +994,7 @@
     "editorBracketHighlight.foreground3": "#98971a",
     "editorBracketHighlight.foreground4": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
-    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -990,8 +990,9 @@
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",
-    "editorBracketHighlight.foreground3": "#98971a",
-    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground3": "#689d6a",
+    "editorBracketHighlight.foreground4": "#98971a",
+    "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -26,21 +26,14 @@
       }
     },
     {
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "foreground": "#928374",
         "fontStyle": "italic"
       }
     },
     {
-      "scope": [
-        "constant",
-        "support.constant",
-        "variable.arguments"
-      ],
+      "scope": ["constant", "support.constant", "variable.arguments"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -64,19 +57,13 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag",
-        "punctuation.tag"
-      ],
+      "scope": ["entity.name.tag", "punctuation.tag"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
-      "scope": [
-        "invalid",
-        "invalid.illegal"
-      ],
+      "scope": ["invalid", "invalid.illegal"],
       "settings": {
         "foreground": "#cc241d"
       }
@@ -266,10 +253,7 @@
       }
     },
     {
-      "scope": [
-        "variable.this",
-        "support.variable"
-      ],
+      "scope": ["variable.this", "support.variable"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -353,9 +337,7 @@
       }
     },
     {
-      "scope": [
-        "punctuation"
-      ],
+      "scope": ["punctuation"],
       "settings": {
         "foreground": "#7c6f64"
       }
@@ -374,11 +356,7 @@
     },
     {
       "name": "URL",
-      "scope": [
-        "*url*",
-        "*link*",
-        "*uri*"
-      ],
+      "scope": ["*url*", "*link*", "*uri*"],
       "settings": {
         "fontStyle": "underline"
       }
@@ -389,10 +367,7 @@
     // PYTHON ----------------------------------------
     {
       "name": "Python function",
-      "scope": [
-        "meta.function.python",
-        "entity.name.function.python"
-      ],
+      "scope": ["meta.function.python", "entity.name.function.python"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -504,10 +479,7 @@
     },
     {
       "name": "C# This",
-      "scope": [
-        "keyword.other.this.cs",
-        "keyword.other.base.cs"
-      ],
+      "scope": ["keyword.other.this.cs", "keyword.other.base.cs"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -538,10 +510,7 @@
       }
     },
     {
-      "scope": [
-        "keyword.other.import.java",
-        "keyword.other.package.java"
-      ],
+      "scope": ["keyword.other.import.java", "keyword.other.package.java"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -660,10 +629,7 @@
       }
     },
     {
-      "scope": [
-        "markup.inline.raw",
-        "markup.fenced_code.block"
-      ],
+      "scope": ["markup.inline.raw", "markup.fenced_code.block"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -759,27 +725,20 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag.css"
-      ],
+      "scope": ["entity.name.tag.css"],
       "settings": {
         "fontStyle": "normal"
       }
     },
     // HTML / XML ----------------------------------------
     {
-      "scope": [
-        "punctuation.definition.tag"
-      ],
+      "scope": ["punctuation.definition.tag"],
       "settings": {
         "foreground": "#076678"
       }
     },
     {
-      "scope": [
-        "text.html entity.name.tag",
-        "text.html punctuation.tag"
-      ],
+      "scope": ["text.html entity.name.tag", "text.html punctuation.tag"],
       "settings": {
         "foreground": "#427b58",
         "fontStyle": "bold"
@@ -787,78 +746,58 @@
     },
     // javascript ---------------------------------------
     {
-      "scope": [
-        "source.js variable.language"
-      ],
+      "scope": ["source.js variable.language"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     // typescript ---------------------------------------
     {
-      "scope": [
-        "source.ts variable.language"
-      ],
+      "scope": ["source.ts variable.language"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     // golang --------------------------------------------
     {
-      "scope": [
-        "source.go storage.type"
-      ],
+      "scope": ["source.go storage.type"],
       "settings": {
         "foreground": "#b57614"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.import"
-      ],
+      "scope": ["source.go entity.name.import"],
       "settings": {
         "foreground": "#79740e"
       }
     },
     {
-      "scope": [
-        "source.go keyword.package",
-        "source.go keyword.import"
-      ],
+      "scope": ["source.go keyword.package", "source.go keyword.import"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
-      "scope": [
-        "source.go keyword.interface",
-        "source.go keyword.struct"
-      ],
+      "scope": ["source.go keyword.interface", "source.go keyword.struct"],
       "settings": {
         "foreground": "#076678"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.type"
-      ],
+      "scope": ["source.go entity.name.type"],
       "settings": {
         "foreground": "#3c3836"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.function"
-      ],
+      "scope": ["source.go entity.name.function"],
       "settings": {
         "foreground": "#8f3f71"
       }
     },
     // cucumber
     {
-      "scope": [
-        "keyword.control.cucumber.table"
-      ],
+      "scope": ["keyword.control.cucumber.table"],
       "settings": {
         "foreground": "#076678"
       }
@@ -866,28 +805,21 @@
     // REASONML ------------------------------------
     {
       "name": "ReasonML String",
-      "scope": [
-        "source.reason string.double",
-        "source.reason string.regexp"
-      ],
+      "scope": ["source.reason string.double", "source.reason string.regexp"],
       "settings": {
         "foreground": "#79740e"
       }
     },
     {
       "name": "ReasonML equals sign",
-      "scope": [
-        "source.reason keyword.control.less"
-      ],
+      "scope": ["source.reason keyword.control.less"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
       "name": "ReasonML variable",
-      "scope": [
-        "source.reason entity.name.function"
-      ],
+      "scope": ["source.reason entity.name.function"],
       "settings": {
         "foreground": "#076678"
       }
@@ -905,27 +837,21 @@
     // POWERSHELL ------------------------------------
     {
       "name": "Powershell member",
-      "scope": [
-        "source.powershell variable.other.member.powershell"
-      ],
+      "scope": ["source.powershell variable.other.member.powershell"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     {
       "name": "Powershell function",
-      "scope": [
-        "source.powershell support.function.powershell"
-      ],
+      "scope": ["source.powershell support.function.powershell"],
       "settings": {
         "foreground": "#b57614"
       }
     },
     {
       "name": "Powershell function attribute",
-      "scope": [
-        "source.powershell support.function.attribute.powershell"
-      ],
+      "scope": ["source.powershell support.function.attribute.powershell"],
       "settings": {
         "foreground": "#665c54"
       }
@@ -1061,6 +987,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - BRACKET PAIR COLORIZATION
+    "editorBracketHighlight.foreground1": "#b16286",
+    "editorBracketHighlight.foreground2": "#458588",
+    "editorBracketHighlight.foreground3": "#98971a",
+    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground6": "#d65d0e",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
     "diffEditor.removedTextBackground": "#9d000630",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -1061,6 +1061,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - BRACKET PAIR COLORIZATION
+    "editorBracketHighlight.foreground1": "#b16286",
+    "editorBracketHighlight.foreground2": "#458588",
+    "editorBracketHighlight.foreground3": "#98971a",
+    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground6": "#d65d0e",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
     "diffEditor.removedTextBackground": "#9d000630",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -990,8 +990,9 @@
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",
-    "editorBracketHighlight.foreground3": "#98971a",
-    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground3": "#689d6a",
+    "editorBracketHighlight.foreground4": "#98971a",
+    "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -26,21 +26,14 @@
       }
     },
     {
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "foreground": "#928374",
         "fontStyle": "italic"
       }
     },
     {
-      "scope": [
-        "constant",
-        "support.constant",
-        "variable.arguments"
-      ],
+      "scope": ["constant", "support.constant", "variable.arguments"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -64,19 +57,13 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag",
-        "punctuation.tag"
-      ],
+      "scope": ["entity.name.tag", "punctuation.tag"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
-      "scope": [
-        "invalid",
-        "invalid.illegal"
-      ],
+      "scope": ["invalid", "invalid.illegal"],
       "settings": {
         "foreground": "#cc241d"
       }
@@ -266,10 +253,7 @@
       }
     },
     {
-      "scope": [
-        "variable.this",
-        "support.variable"
-      ],
+      "scope": ["variable.this", "support.variable"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -353,9 +337,7 @@
       }
     },
     {
-      "scope": [
-        "punctuation"
-      ],
+      "scope": ["punctuation"],
       "settings": {
         "foreground": "#7c6f64"
       }
@@ -374,11 +356,7 @@
     },
     {
       "name": "URL",
-      "scope": [
-        "*url*",
-        "*link*",
-        "*uri*"
-      ],
+      "scope": ["*url*", "*link*", "*uri*"],
       "settings": {
         "fontStyle": "underline"
       }
@@ -389,10 +367,7 @@
     // PYTHON ----------------------------------------
     {
       "name": "Python function",
-      "scope": [
-        "meta.function.python",
-        "entity.name.function.python"
-      ],
+      "scope": ["meta.function.python", "entity.name.function.python"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -504,10 +479,7 @@
     },
     {
       "name": "C# This",
-      "scope": [
-        "keyword.other.this.cs",
-        "keyword.other.base.cs"
-      ],
+      "scope": ["keyword.other.this.cs", "keyword.other.base.cs"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -538,10 +510,7 @@
       }
     },
     {
-      "scope": [
-        "keyword.other.import.java",
-        "keyword.other.package.java"
-      ],
+      "scope": ["keyword.other.import.java", "keyword.other.package.java"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -660,10 +629,7 @@
       }
     },
     {
-      "scope": [
-        "markup.inline.raw",
-        "markup.fenced_code.block"
-      ],
+      "scope": ["markup.inline.raw", "markup.fenced_code.block"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -759,27 +725,20 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag.css"
-      ],
+      "scope": ["entity.name.tag.css"],
       "settings": {
         "fontStyle": "normal"
       }
     },
     // HTML / XML ----------------------------------------
     {
-      "scope": [
-        "punctuation.definition.tag"
-      ],
+      "scope": ["punctuation.definition.tag"],
       "settings": {
         "foreground": "#076678"
       }
     },
     {
-      "scope": [
-        "text.html entity.name.tag",
-        "text.html punctuation.tag"
-      ],
+      "scope": ["text.html entity.name.tag", "text.html punctuation.tag"],
       "settings": {
         "foreground": "#427b58",
         "fontStyle": "bold"
@@ -787,78 +746,58 @@
     },
     // javascript ---------------------------------------
     {
-      "scope": [
-        "source.js variable.language"
-      ],
+      "scope": ["source.js variable.language"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     // typescript ---------------------------------------
     {
-      "scope": [
-        "source.ts variable.language"
-      ],
+      "scope": ["source.ts variable.language"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     // golang --------------------------------------------
     {
-      "scope": [
-        "source.go storage.type"
-      ],
+      "scope": ["source.go storage.type"],
       "settings": {
         "foreground": "#b57614"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.import"
-      ],
+      "scope": ["source.go entity.name.import"],
       "settings": {
         "foreground": "#79740e"
       }
     },
     {
-      "scope": [
-        "source.go keyword.package",
-        "source.go keyword.import"
-      ],
+      "scope": ["source.go keyword.package", "source.go keyword.import"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
-      "scope": [
-        "source.go keyword.interface",
-        "source.go keyword.struct"
-      ],
+      "scope": ["source.go keyword.interface", "source.go keyword.struct"],
       "settings": {
         "foreground": "#076678"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.type"
-      ],
+      "scope": ["source.go entity.name.type"],
       "settings": {
         "foreground": "#3c3836"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.function"
-      ],
+      "scope": ["source.go entity.name.function"],
       "settings": {
         "foreground": "#8f3f71"
       }
     },
     // cucumber
     {
-      "scope": [
-        "keyword.control.cucumber.table"
-      ],
+      "scope": ["keyword.control.cucumber.table"],
       "settings": {
         "foreground": "#076678"
       }
@@ -866,28 +805,21 @@
     // REASONML ------------------------------------
     {
       "name": "ReasonML String",
-      "scope": [
-        "source.reason string.double",
-        "source.reason string.regexp"
-      ],
+      "scope": ["source.reason string.double", "source.reason string.regexp"],
       "settings": {
         "foreground": "#79740e"
       }
     },
     {
       "name": "ReasonML equals sign",
-      "scope": [
-        "source.reason keyword.control.less"
-      ],
+      "scope": ["source.reason keyword.control.less"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
       "name": "ReasonML variable",
-      "scope": [
-        "source.reason entity.name.function"
-      ],
+      "scope": ["source.reason entity.name.function"],
       "settings": {
         "foreground": "#076678"
       }
@@ -905,27 +837,21 @@
     // POWERSHELL ------------------------------------
     {
       "name": "Powershell member",
-      "scope": [
-        "source.powershell variable.other.member.powershell"
-      ],
+      "scope": ["source.powershell variable.other.member.powershell"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     {
       "name": "Powershell function",
-      "scope": [
-        "source.powershell support.function.powershell"
-      ],
+      "scope": ["source.powershell support.function.powershell"],
       "settings": {
         "foreground": "#b57614"
       }
     },
     {
       "name": "Powershell function attribute",
-      "scope": [
-        "source.powershell support.function.attribute.powershell"
-      ],
+      "scope": ["source.powershell support.function.attribute.powershell"],
       "settings": {
         "foreground": "#665c54"
       }
@@ -1067,7 +993,7 @@
     "editorBracketHighlight.foreground3": "#98971a",
     "editorBracketHighlight.foreground4": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
-    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
     "diffEditor.removedTextBackground": "#9d000630",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -1061,6 +1061,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - BRACKET PAIR COLORIZATION
+    "editorBracketHighlight.foreground1": "#b16286",
+    "editorBracketHighlight.foreground2": "#458588",
+    "editorBracketHighlight.foreground3": "#98971a",
+    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground6": "#d65d0e",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
     "diffEditor.removedTextBackground": "#9d000630",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -990,8 +990,9 @@
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",
-    "editorBracketHighlight.foreground3": "#98971a",
-    "editorBracketHighlight.foreground4": "#d79921",
+    "editorBracketHighlight.foreground3": "#689d6a",
+    "editorBracketHighlight.foreground4": "#98971a",
+    "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -26,21 +26,14 @@
       }
     },
     {
-      "scope": [
-        "comment",
-        "punctuation.definition.comment"
-      ],
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "foreground": "#928374",
         "fontStyle": "italic"
       }
     },
     {
-      "scope": [
-        "constant",
-        "support.constant",
-        "variable.arguments"
-      ],
+      "scope": ["constant", "support.constant", "variable.arguments"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -64,19 +57,13 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag",
-        "punctuation.tag"
-      ],
+      "scope": ["entity.name.tag", "punctuation.tag"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
-      "scope": [
-        "invalid",
-        "invalid.illegal"
-      ],
+      "scope": ["invalid", "invalid.illegal"],
       "settings": {
         "foreground": "#cc241d"
       }
@@ -266,10 +253,7 @@
       }
     },
     {
-      "scope": [
-        "variable.this",
-        "support.variable"
-      ],
+      "scope": ["variable.this", "support.variable"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -353,9 +337,7 @@
       }
     },
     {
-      "scope": [
-        "punctuation"
-      ],
+      "scope": ["punctuation"],
       "settings": {
         "foreground": "#7c6f64"
       }
@@ -374,11 +356,7 @@
     },
     {
       "name": "URL",
-      "scope": [
-        "*url*",
-        "*link*",
-        "*uri*"
-      ],
+      "scope": ["*url*", "*link*", "*uri*"],
       "settings": {
         "fontStyle": "underline"
       }
@@ -389,10 +367,7 @@
     // PYTHON ----------------------------------------
     {
       "name": "Python function",
-      "scope": [
-        "meta.function.python",
-        "entity.name.function.python"
-      ],
+      "scope": ["meta.function.python", "entity.name.function.python"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -504,10 +479,7 @@
     },
     {
       "name": "C# This",
-      "scope": [
-        "keyword.other.this.cs",
-        "keyword.other.base.cs"
-      ],
+      "scope": ["keyword.other.this.cs", "keyword.other.base.cs"],
       "settings": {
         "foreground": "#8f3f71"
       }
@@ -538,10 +510,7 @@
       }
     },
     {
-      "scope": [
-        "keyword.other.import.java",
-        "keyword.other.package.java"
-      ],
+      "scope": ["keyword.other.import.java", "keyword.other.package.java"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -660,10 +629,7 @@
       }
     },
     {
-      "scope": [
-        "markup.inline.raw",
-        "markup.fenced_code.block"
-      ],
+      "scope": ["markup.inline.raw", "markup.fenced_code.block"],
       "settings": {
         "foreground": "#427b58"
       }
@@ -759,27 +725,20 @@
       }
     },
     {
-      "scope": [
-        "entity.name.tag.css"
-      ],
+      "scope": ["entity.name.tag.css"],
       "settings": {
         "fontStyle": "normal"
       }
     },
     // HTML / XML ----------------------------------------
     {
-      "scope": [
-        "punctuation.definition.tag"
-      ],
+      "scope": ["punctuation.definition.tag"],
       "settings": {
         "foreground": "#076678"
       }
     },
     {
-      "scope": [
-        "text.html entity.name.tag",
-        "text.html punctuation.tag"
-      ],
+      "scope": ["text.html entity.name.tag", "text.html punctuation.tag"],
       "settings": {
         "foreground": "#427b58",
         "fontStyle": "bold"
@@ -787,78 +746,58 @@
     },
     // javascript ---------------------------------------
     {
-      "scope": [
-        "source.js variable.language"
-      ],
+      "scope": ["source.js variable.language"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     // typescript ---------------------------------------
     {
-      "scope": [
-        "source.ts variable.language"
-      ],
+      "scope": ["source.ts variable.language"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     // golang --------------------------------------------
     {
-      "scope": [
-        "source.go storage.type"
-      ],
+      "scope": ["source.go storage.type"],
       "settings": {
         "foreground": "#b57614"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.import"
-      ],
+      "scope": ["source.go entity.name.import"],
       "settings": {
         "foreground": "#79740e"
       }
     },
     {
-      "scope": [
-        "source.go keyword.package",
-        "source.go keyword.import"
-      ],
+      "scope": ["source.go keyword.package", "source.go keyword.import"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
-      "scope": [
-        "source.go keyword.interface",
-        "source.go keyword.struct"
-      ],
+      "scope": ["source.go keyword.interface", "source.go keyword.struct"],
       "settings": {
         "foreground": "#076678"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.type"
-      ],
+      "scope": ["source.go entity.name.type"],
       "settings": {
         "foreground": "#3c3836"
       }
     },
     {
-      "scope": [
-        "source.go entity.name.function"
-      ],
+      "scope": ["source.go entity.name.function"],
       "settings": {
         "foreground": "#8f3f71"
       }
     },
     // cucumber
     {
-      "scope": [
-        "keyword.control.cucumber.table"
-      ],
+      "scope": ["keyword.control.cucumber.table"],
       "settings": {
         "foreground": "#076678"
       }
@@ -866,28 +805,21 @@
     // REASONML ------------------------------------
     {
       "name": "ReasonML String",
-      "scope": [
-        "source.reason string.double",
-        "source.reason string.regexp"
-      ],
+      "scope": ["source.reason string.double", "source.reason string.regexp"],
       "settings": {
         "foreground": "#79740e"
       }
     },
     {
       "name": "ReasonML equals sign",
-      "scope": [
-        "source.reason keyword.control.less"
-      ],
+      "scope": ["source.reason keyword.control.less"],
       "settings": {
         "foreground": "#427b58"
       }
     },
     {
       "name": "ReasonML variable",
-      "scope": [
-        "source.reason entity.name.function"
-      ],
+      "scope": ["source.reason entity.name.function"],
       "settings": {
         "foreground": "#076678"
       }
@@ -905,27 +837,21 @@
     // POWERSHELL ------------------------------------
     {
       "name": "Powershell member",
-      "scope": [
-        "source.powershell variable.other.member.powershell"
-      ],
+      "scope": ["source.powershell variable.other.member.powershell"],
       "settings": {
         "foreground": "#af3a03"
       }
     },
     {
       "name": "Powershell function",
-      "scope": [
-        "source.powershell support.function.powershell"
-      ],
+      "scope": ["source.powershell support.function.powershell"],
       "settings": {
         "foreground": "#b57614"
       }
     },
     {
       "name": "Powershell function attribute",
-      "scope": [
-        "source.powershell support.function.attribute.powershell"
-      ],
+      "scope": ["source.powershell support.function.attribute.powershell"],
       "settings": {
         "foreground": "#665c54"
       }
@@ -1067,7 +993,7 @@
     "editorBracketHighlight.foreground3": "#98971a",
     "editorBracketHighlight.foreground4": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
-    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d"
+    "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
     "diffEditor.removedTextBackground": "#9d000630",


### PR DESCRIPTION
This PR implements bracket pair colourisation for VS Code. I've run a few experriments that ended up informing my decisions, namely:

1. It looks like all text colours are the same within the variations of a theme – i.e. Gruvbox Dark Soft, Medium and Hard use the same font colours. Following this logic, same bracket colours are proposed for all variations.
2. In terms of the sequence of particular colours, the rainbow sequence seemed to make the most logical and aesthetical sense. Both Orange to Purple and Purple to Orange were tested, and the latter was found to be subjectively more readable for most language examples. Finally, red was used for unexpected/unbalanced brackets.
3. Since Colour 2 is used for text in both Light and Dark themes, using Colour 1 makes brackets slightly distinguishable from the rest of the tokens, thus subjectively improving readability.
4. As for the place to include the rules, they were put into the end of the `editor.` block.

PS: some Prettier JSON auto-formatting trickled into the files. This alters formatting but does nothing to the semantics. My apologies for that. If this turns out to be a critical issue, I will revert and re-commit. Feel free to point this out if this is the case.