### PR TITLE
feat: add inlay hint support

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -989,12 +989,10 @@
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
     // EDITOR - INLAY HINTS
-    "editorInlayHint.background": "#3c3836",
+    "editorInlayHint.background": "#3c383680",
     "editorInlayHint.foreground": "#928374",
-    "editorInlayHint.typeBackground": "#3c3836",
-    "editorInlayHint.typeForeground": "#d7992180",
-    "editorInlayHint.paramBackground": "#3c3836",
-    "editorInlayHint.paramForeground": "#45858880",
+    "editorInlayHint.typeForeground": "#d79921",
+    "editorInlayHint.paramForeground": "#458588",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -988,6 +988,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - INLAY HINTS
+    "editorInlayHint.background": "#3c3836",
+    "editorInlayHint.foreground": "#928374",
+    "editorInlayHint.typeBackground": "#3c3836",
+    "editorInlayHint.typeForeground": "#d7992180",
+    "editorInlayHint.paramBackground": "#3c3836",
+    "editorInlayHint.paramForeground": "#45858880",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -989,12 +989,10 @@
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
     // EDITOR - INLAY HINTS
-    "editorInlayHint.background": "#3c3836",
+    "editorInlayHint.background": "#3c383680",
     "editorInlayHint.foreground": "#928374",
-    "editorInlayHint.typeBackground": "#3c3836",
-    "editorInlayHint.typeForeground": "#d7992180",
-    "editorInlayHint.paramBackground": "#3c3836",
-    "editorInlayHint.paramForeground": "#45858880",
+    "editorInlayHint.typeForeground": "#d79921",
+    "editorInlayHint.paramForeground": "#458588",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -988,6 +988,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - INLAY HINTS
+    "editorInlayHint.background": "#3c3836",
+    "editorInlayHint.foreground": "#928374",
+    "editorInlayHint.typeBackground": "#3c3836",
+    "editorInlayHint.typeForeground": "#d7992180",
+    "editorInlayHint.paramBackground": "#3c3836",
+    "editorInlayHint.paramForeground": "#45858880",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -989,12 +989,10 @@
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
     // EDITOR - INLAY HINTS
-    "editorInlayHint.background": "#3c3836",
+    "editorInlayHint.background": "#3c383680",
     "editorInlayHint.foreground": "#928374",
-    "editorInlayHint.typeBackground": "#3c3836",
-    "editorInlayHint.typeForeground": "#d7992180",
-    "editorInlayHint.paramBackground": "#3c3836",
-    "editorInlayHint.paramForeground": "#45858880",
+    "editorInlayHint.typeForeground": "#d79921",
+    "editorInlayHint.paramForeground": "#458588",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -988,6 +988,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - INLAY HINTS
+    "editorInlayHint.background": "#3c3836",
+    "editorInlayHint.foreground": "#928374",
+    "editorInlayHint.typeBackground": "#3c3836",
+    "editorInlayHint.typeForeground": "#d7992180",
+    "editorInlayHint.paramBackground": "#3c3836",
+    "editorInlayHint.paramForeground": "#45858880",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -988,12 +988,10 @@
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
     // EDITOR - INLAY HINTS
-    "editorInlayHint.background": "#ebdbb2",
+    "editorInlayHint.background": "#ebdbb280",
     "editorInlayHint.foreground": "#928374",
-    "editorInlayHint.typeBackground": "#ebdbb2",
-    "editorInlayHint.typeForeground": "#b5761480",
-    "editorInlayHint.paramBackground": "#ebdbb2",
-    "editorInlayHint.paramForeground": "#07667880",
+    "editorInlayHint.typeForeground": "#b57614",
+    "editorInlayHint.paramForeground": "#076678",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -987,6 +987,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - INLAY HINTS
+    "editorInlayHint.background": "#ebdbb2",
+    "editorInlayHint.foreground": "#928374",
+    "editorInlayHint.typeBackground": "#ebdbb2",
+    "editorInlayHint.typeForeground": "#b5761480",
+    "editorInlayHint.paramBackground": "#ebdbb2",
+    "editorInlayHint.paramForeground": "#07667880",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -988,12 +988,10 @@
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
     // EDITOR - INLAY HINTS
-    "editorInlayHint.background": "#ebdbb2",
+    "editorInlayHint.background": "#ebdbb280",
     "editorInlayHint.foreground": "#928374",
-    "editorInlayHint.typeBackground": "#ebdbb2",
-    "editorInlayHint.typeForeground": "#b5761480",
-    "editorInlayHint.paramBackground": "#ebdbb2",
-    "editorInlayHint.paramForeground": "#07667880",
+    "editorInlayHint.typeForeground": "#b57614",
+    "editorInlayHint.paramForeground": "#076678",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -987,6 +987,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - INLAY HINTS
+    "editorInlayHint.background": "#ebdbb2",
+    "editorInlayHint.foreground": "#928374",
+    "editorInlayHint.typeBackground": "#ebdbb2",
+    "editorInlayHint.typeForeground": "#b5761480",
+    "editorInlayHint.paramBackground": "#ebdbb2",
+    "editorInlayHint.paramForeground": "#07667880",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -988,12 +988,10 @@
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
     // EDITOR - INLAY HINTS
-    "editorInlayHint.background": "#ebdbb2",
+    "editorInlayHint.background": "#ebdbb280",
     "editorInlayHint.foreground": "#928374",
-    "editorInlayHint.typeBackground": "#ebdbb2",
-    "editorInlayHint.typeForeground": "#b5761480",
-    "editorInlayHint.paramBackground": "#ebdbb2",
-    "editorInlayHint.paramForeground": "#07667880",
+    "editorInlayHint.typeForeground": "#b57614",
+    "editorInlayHint.paramForeground": "#076678",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -987,6 +987,13 @@
     "editorError.foreground": "#cc241d",
     "editorWarning.foreground": "#d79921",
     "editorInfo.foreground": "#458588",
+    // EDITOR - INLAY HINTS
+    "editorInlayHint.background": "#ebdbb2",
+    "editorInlayHint.foreground": "#928374",
+    "editorInlayHint.typeBackground": "#ebdbb2",
+    "editorInlayHint.typeForeground": "#b5761480",
+    "editorInlayHint.paramBackground": "#ebdbb2",
+    "editorInlayHint.paramForeground": "#07667880",
     // EDITOR - BRACKET PAIR COLORIZATION
     "editorBracketHighlight.foreground1": "#b16286",
     "editorBracketHighlight.foreground2": "#458588",


### PR DESCRIPTION
Added inlay hint color for the theme.

I'm not very sure about the color selection -- I'm currently using the color 'gray' in the color scheme as the text color for regular inlay hints, and the `{color}1` version of the type and parameter color for type/parameter inlay hints.

Before: see https://github.com/jdinhify/vscode-theme-gruvbox/issues/68

After:

![图片](https://user-images.githubusercontent.com/10259119/204072570-5f2727d1-35c9-4156-bde2-d3ea7b1fff0e.png)

![图片](https://user-images.githubusercontent.com/10259119/204072806-4818d935-8ad1-47e7-a48f-bbd6cc09b733.png)
