### PR TITLE
Add menu separator color to match with menu border

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -1074,6 +1074,7 @@
     "gitDecoration.conflictingResourceForeground": "#b16286",
     // MENU BAR
     "menu.border": "#3c3836",
+    "menu.separatorBackground": "#3c3836",
     // JUPYTER NOTEBOOKS
     "notebook.cellEditorBackground": "#282828",
     "notebook.focusedCellBorder": "#a89984",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -1074,6 +1074,7 @@
     "gitDecoration.conflictingResourceForeground": "#b16286",
     // MENU BAR
     "menu.border": "#3c3836",
+    "menu.separatorBackground": "#3c3836",
     // JUPYTER NOTEBOOKS
     "notebook.cellEditorBackground": "#32302f",
     "notebook.focusedCellBorder": "#a89984",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -1074,6 +1074,7 @@
     "gitDecoration.conflictingResourceForeground": "#b16286",
     // MENU BAR
     "menu.border": "#3c3836",
+    "menu.separatorBackground": "#3c3836",
     // JUPYTER NOTEBOOKS
     "notebook.cellEditorBackground": "#282828",
     "notebook.focusedCellBorder": "#a89984",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -1073,6 +1073,7 @@
     "gitDecoration.conflictingResourceForeground": "#b16286",
     // MENU BAR
     "menu.border": "#ebdbb2",
+    "menu.separatorBackground": "#ebdbb2",
     // JUPYTER NOTEBOOKS
     "notebook.cellEditorBackground": "#fbf1c7",
     "notebook.focusedCellBorder": "#7c6f64",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -1073,6 +1073,7 @@
     "gitDecoration.conflictingResourceForeground": "#b16286",
     // MENU BAR
     "menu.border": "#ebdbb2",
+    "menu.separatorBackground": "#ebdbb2",
     // JUPYTER NOTEBOOKS
     "notebook.cellEditorBackground": "#f2e5bc",
     "notebook.focusedCellBorder": "#665c54",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -1073,6 +1073,7 @@
     "gitDecoration.conflictingResourceForeground": "#b16286",
     // MENU BAR
     "menu.border": "#ebdbb2",
+    "menu.separatorBackground": "#ebdbb2",
     // JUPYTER NOTEBOOKS
     "notebook.cellEditorBackground": "#ebdbb2",
     "notebook.focusedCellBorder": "#665c54",


### PR DESCRIPTION
On Windows, the menu separator isn’t assigned a color so it can be a little bit out of place, like this:

![2853FAFD-CA12-43CA-A7AB-537435BA5D0E](https://user-images.githubusercontent.com/75784849/221091901-4688b9d9-c994-4983-ac9c-793deb9be812.png)

I think separator color should be set to the same color as border’s to make it consistent:

![6FB121B6-A095-4226-BE83-27FCBA9FE0B1](https://user-images.githubusercontent.com/75784849/221092155-b9bda23e-a068-43e0-ab77-ce35a6b582e7.png)

