### PR TITLE
Enabled semantic highlighting

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -1,6 +1,7 @@
 {
   "name": "Gruvbox Dark Hard",
   "type": "dark",
+  "semanticHighlighting": true,
   "tokenColors": [
     {
       "settings": {

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -1,6 +1,7 @@
 {
   "name": "Gruvbox Dark Medium",
   "type": "dark",
+  "semanticHighlighting": true,
   "tokenColors": [
     {
       "settings": {

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -1,6 +1,7 @@
 {
   "name": "Gruvbox Dark Soft",
   "type": "dark",
+  "semanticHighlighting": true,
   "tokenColors": [
     {
       "settings": {

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -1,5 +1,6 @@
 {
   "name": "Gruvbox Light Hard",
+  "semanticHighlighting": true,
   "tokenColors": [
     {
       "settings": {

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -1,5 +1,6 @@
 {
   "name": "Gruvbox Light Medium",
+  "semanticHighlighting": true,
   "tokenColors": [
     {
       "settings": {

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -1,5 +1,6 @@
 {
   "name": "Gruvbox Light Soft",
+  "semanticHighlighting": true,
   "tokenColors": [
     {
       "settings": {


### PR DESCRIPTION
Enabled semantic highlighting on all themes. See the VS Code [Semantic Highlighting Guide](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide) for more information.

In the examples below you will see the difference in how functions are highlighted. This is closer to how the modern built-in VS Code themes work.

# Before
![Screenshot 2023-08-23 at 11 50 46 AM](https://github.com/jdinhify/vscode-theme-gruvbox/assets/18314366/244faea6-6cfa-43c7-9b11-b493303247a4)

# After
![Screenshot 2023-08-23 at 11 51 27 AM](https://github.com/jdinhify/vscode-theme-gruvbox/assets/18314366/c2160fc8-f37c-4a30-a012-cefdbbec3888)
