### PR TITLE
Added special semantic coloring for consts, readonly properties, and enums.

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -326,6 +326,13 @@
       }
     },
     {
+      "name": "constants",
+			"scope": ["variable.other.constant", "variable.other.enummember"],
+			"settings": {
+        "foreground": "#458588"
+			}
+		},
+    {
       "scope": "prototype",
       "settings": {
         "foreground": "#d3869b"

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -326,6 +326,13 @@
       }
     },
     {
+      "name": "constants",
+			"scope": ["variable.other.constant", "variable.other.enummember"],
+			"settings": {
+        "foreground": "#458588"
+			}
+		},
+    {
       "scope": "prototype",
       "settings": {
         "foreground": "#d3869b"

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -326,6 +326,13 @@
       }
     },
     {
+      "name": "constants",
+			"scope": ["variable.other.constant", "variable.other.enummember"],
+			"settings": {
+        "foreground": "#458588"
+			}
+		},
+    {
       "scope": "prototype",
       "settings": {
         "foreground": "#d3869b"

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -321,9 +321,16 @@
         "string.constant.other.placeholder"
       ],
       "settings": {
-        "foreground": "#076678"
+        "foreground": "#458588"
       }
     },
+    {
+      "name": "constants",
+			"scope": ["variable.other.constant", "variable.other.enummember"],
+			"settings": {
+        "foreground": "#076678"
+			}
+		},
     {
       "scope": "prototype",
       "settings": {

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -321,9 +321,16 @@
         "string.constant.other.placeholder"
       ],
       "settings": {
-        "foreground": "#076678"
+        "foreground": "#458588"
       }
     },
+    {
+      "name": "constants",
+			"scope": ["variable.other.constant", "variable.other.enummember"],
+			"settings": {
+        "foreground": "#076678"
+			}
+		},
     {
       "scope": "prototype",
       "settings": {

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -321,9 +321,16 @@
         "string.constant.other.placeholder"
       ],
       "settings": {
-        "foreground": "#076678"
+        "foreground": "#458588"
       }
     },
+    {
+      "name": "constants",
+			"scope": ["variable.other.constant", "variable.other.enummember"],
+			"settings": {
+        "foreground": "#076678"
+			}
+		},
     {
       "scope": "prototype",
       "settings": {


### PR DESCRIPTION
This PR depends upon https://github.com/jdinhify/vscode-theme-gruvbox/pull/80 because it requires semantic highlighting to be enabled.

The examples below demonstrate the changes to how constant/read-only tokens are colored. This is similar to how the modern built-in VS Code themes behave. (**Note:** Colors taken from the [original Gruvbox palette](https://github.com/morhetz/gruvbox))

# Before
![Screenshot 2023-08-23 at 12 27 02 PM](https://github.com/jdinhify/vscode-theme-gruvbox/assets/18314366/ea79b769-16bf-4c80-9b65-a0d245e114bf) ![Screenshot 2023-08-23 at 12 35 02 PM](https://github.com/jdinhify/vscode-theme-gruvbox/assets/18314366/c2fcd14b-a14e-4748-8cc7-25547922a6d1)

# After
![Screenshot 2023-08-23 at 12 26 37 PM](https://github.com/jdinhify/vscode-theme-gruvbox/assets/18314366/a330a016-50f1-4568-9978-dc8a2b81fdde) ![Screenshot 2023-08-23 at 12 35 19 PM](https://github.com/jdinhify/vscode-theme-gruvbox/assets/18314366/d06b7d9d-e386-40e4-8e00-ede37cbc1820)
