### PR TITLE
Adding component semantic colors

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -1084,6 +1084,7 @@
     "variable": "#ebdbb2",
     "function": "#8ec07c",
     "function.builtin": "#fe8019",
-    "method": "#8ec07c"
+    "method": "#8ec07c",
+    "component": "#fe8019"
   }
 }

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -1084,6 +1084,7 @@
     "variable": "#ebdbb2",
     "function": "#8ec07c",
     "function.builtin": "#fe8019",
-    "method": "#8ec07c"
+    "method": "#8ec07c",
+    "component": "#fe8019"
   }
 }

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -1084,6 +1084,7 @@
     "variable": "#ebdbb2",
     "function": "#8ec07c",
     "function.builtin": "#fe8019",
-    "method": "#8ec07c"
+    "method": "#8ec07c",
+    "component": "#fe8019"
   }
 }

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -1083,6 +1083,7 @@
     "variable": "#3c3836",
     "function": "#427b58",
     "function.builtin": "#af3a03",
-    "method": "#427b58"
+    "method": "#427b58",
+    "component": "#af3a03"
   }
 }

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -1083,6 +1083,7 @@
     "variable": "#3c3836",
     "function": "#427b58",
     "function.builtin": "#af3a03",
-    "method": "#427b58"
+    "method": "#427b58",
+    "component": "#af3a03"
   }
 }

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -1083,6 +1083,7 @@
     "variable": "#3c3836",
     "function": "#427b58",
     "function.builtin": "#af3a03",
-    "method": "#427b58"
+    "method": "#427b58",
+    "component": "#af3a03"
   }
 }


### PR DESCRIPTION
This adds colors to component tags for JavaScript frameworks like Vue.

Here is an example:

Before:
![before](https://github.com/jdinhify/vscode-theme-gruvbox/assets/12666122/fb142b2b-f384-43fb-b589-376bfd607a86)

After:
![after](https://github.com/jdinhify/vscode-theme-gruvbox/assets/12666122/55fed089-e247-4126-98ad-18dc2ea8af21)

Before:
![light-before](https://github.com/jdinhify/vscode-theme-gruvbox/assets/12666122/4e3fe71f-a325-401e-b11f-3710bf127f10)

After:
![light-after](https://github.com/jdinhify/vscode-theme-gruvbox/assets/12666122/d64afa86-a015-4625-89c7-08f305d1b754)
