### PR TITLE
Set the noTabsBackground to the same as editor background

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -924,7 +924,7 @@
     // EDITOR GROUPS
     "editorGroup.border": "#3c3836",
     "editorGroup.dropBackground": "#3c383660",
-    "editorGroupHeader.noTabsBackground": "#3c3836",
+    "editorGroupHeader.noTabsBackground": "#1d2021",
     "editorGroupHeader.tabsBackground": "#1d2021",
     "editorGroupHeader.tabsBorder": "#3c3836",
     // TABS

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -924,7 +924,7 @@
     // EDITOR GROUPS
     "editorGroup.border": "#3c3836",
     "editorGroup.dropBackground": "#3c383660",
-    "editorGroupHeader.noTabsBackground": "#3c3836",
+    "editorGroupHeader.noTabsBackground": "#282828",
     "editorGroupHeader.tabsBackground": "#282828",
     "editorGroupHeader.tabsBorder": "#3c3836",
     // TABS

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -924,7 +924,7 @@
     // EDITOR GROUPS
     "editorGroup.border": "#3c3836",
     "editorGroup.dropBackground": "#3c383660",
-    "editorGroupHeader.noTabsBackground": "#3c3836",
+    "editorGroupHeader.noTabsBackground": "#32302f",
     "editorGroupHeader.tabsBackground": "#32302f",
     "editorGroupHeader.tabsBorder": "#3c3836",
     // TABS

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -923,7 +923,7 @@
     // EDITOR GROUPS
     "editorGroup.border": "#ebdbb2",
     "editorGroup.dropBackground": "#ebdbb260",
-    "editorGroupHeader.noTabsBackground": "#ebdbb2",
+    "editorGroupHeader.noTabsBackground": "#f9f5d7",
     "editorGroupHeader.tabsBackground": "#f9f5d7",
     "editorGroupHeader.tabsBorder": "#ebdbb2",
     // TABS

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -923,7 +923,7 @@
     // EDITOR GROUPS
     "editorGroup.border": "#ebdbb2",
     "editorGroup.dropBackground": "#ebdbb260",
-    "editorGroupHeader.noTabsBackground": "#ebdbb2",
+    "editorGroupHeader.noTabsBackground": "#fbf1c7",
     "editorGroupHeader.tabsBackground": "#fbf1c7",
     "editorGroupHeader.tabsBorder": "#ebdbb2",
     // TABS

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -923,7 +923,7 @@
     // EDITOR GROUPS
     "editorGroup.border": "#ebdbb2",
     "editorGroup.dropBackground": "#ebdbb260",
-    "editorGroupHeader.noTabsBackground": "#ebdbb2",
+    "editorGroupHeader.noTabsBackground": "#f2e5bc",
     "editorGroupHeader.tabsBackground": "#f2e5bc",
     "editorGroupHeader.tabsBorder": "#ebdbb2",
     // TABS


### PR DESCRIPTION
Before:
<img width="1078" alt="Screenshot 2024-03-03 at 01 23 26" src="https://github.com/jdinhify/vscode-theme-gruvbox/assets/152562831/89a69102-b6a4-4a41-b863-99f53dc42d8c">

After:
<img width="1078" alt="Screenshot 2024-03-03 at 01 25 41" src="https://github.com/jdinhify/vscode-theme-gruvbox/assets/152562831/f979ffb0-1bd6-4433-90cf-0762e0f8b5d3">
