### PR TITLE
fix: no transparent background for input errors

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -881,7 +881,7 @@
     "input.foreground": "#ebdbb2",
     "input.placeholderForeground": "#ebdbb260",
     "inputValidation.errorBorder": "#fb4934",
-    "inputValidation.errorBackground": "#cc241d80",
+    "inputValidation.errorBackground": "#cc241d",
     "inputValidation.infoBorder": "#83a598",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#fabd2f",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -881,7 +881,7 @@
     "input.foreground": "#ebdbb2",
     "input.placeholderForeground": "#ebdbb260",
     "inputValidation.errorBorder": "#fb4934",
-    "inputValidation.errorBackground": "#cc241d80",
+    "inputValidation.errorBackground": "#cc241d",
     "inputValidation.infoBorder": "#83a598",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#fabd2f",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -881,7 +881,7 @@
     "input.foreground": "#ebdbb2",
     "input.placeholderForeground": "#ebdbb260",
     "inputValidation.errorBorder": "#fb4934",
-    "inputValidation.errorBackground": "#cc241d80",
+    "inputValidation.errorBackground": "#cc241d",
     "inputValidation.infoBorder": "#83a598",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#fabd2f",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -880,7 +880,7 @@
     "input.foreground": "#3c3836",
     "input.placeholderForeground": "#3c383660",
     "inputValidation.errorBorder": "#9d0006",
-    "inputValidation.errorBackground": "#cc241d80",
+    "inputValidation.errorBackground": "#cc241d",
     "inputValidation.infoBorder": "#076678",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#b57614",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -880,7 +880,7 @@
     "input.foreground": "#3c3836",
     "input.placeholderForeground": "#3c383660",
     "inputValidation.errorBorder": "#9d0006",
-    "inputValidation.errorBackground": "#cc241d80",
+    "inputValidation.errorBackground": "#cc241d",
     "inputValidation.infoBorder": "#076678",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#b57614",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -880,7 +880,7 @@
     "input.foreground": "#3c3836",
     "input.placeholderForeground": "#3c383660",
     "inputValidation.errorBorder": "#9d0006",
-    "inputValidation.errorBackground": "#cc241d80",
+    "inputValidation.errorBackground": "#cc241d",
     "inputValidation.infoBorder": "#076678",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#b57614",


### PR DESCRIPTION
Hey,

I've encountered an issue where the input validation has almost transparent background, which doesn't look good. In this PR, I've fixed this issue, although I'm not entirely sure if it's the most correct way to do it. We can discuss this further to determine the best approach

Before

<img width="192" alt="image" src="https://github.com/jdinhify/vscode-theme-gruvbox/assets/14910239/0d0f75d3-f2f4-4ced-a9d3-1bd121728e23">


After 
<img width="323" alt="image" src="https://github.com/jdinhify/vscode-theme-gruvbox/assets/14910239/b56e0916-fc9e-4192-8b0c-3e26e4b9f3f6">
