### PR TITLE
fix: add activityBarTop foreground and background colors

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -920,6 +920,8 @@
     "activityBar.background": "#1d2021",
     "activityBar.foreground": "#ebdbb2",
     "activityBar.border": "#3c3836",
+    "activityBarTop.background": "#1d2021",
+    "activityBarTop.foreground": "#ebdbb2",
     "activityBarBadge.background": "#458588",
     "activityBarBadge.foreground": "#ebdbb2",
     // EDITOR GROUPS

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -920,6 +920,8 @@
     "activityBar.background": "#282828",
     "activityBar.foreground": "#ebdbb2",
     "activityBar.border": "#3c3836",
+    "activityBarTop.background": "#282828",
+    "activityBarTop.foreground": "#ebdbb2",
     "activityBarBadge.background": "#458588",
     "activityBarBadge.foreground": "#ebdbb2",
     // EDITOR GROUPS

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -920,6 +920,8 @@
     "activityBar.background": "#32302f",
     "activityBar.foreground": "#ebdbb2",
     "activityBar.border": "#3c3836",
+    "activityBarTop.background": "#32302f",
+    "activityBarTop.foreground": "#ebdbb2",
     "activityBarBadge.background": "#458588",
     "activityBarBadge.foreground": "#ebdbb2",
     // EDITOR GROUPS

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -919,6 +919,8 @@
     "activityBar.background": "#f9f5d7",
     "activityBar.foreground": "#3c3836",
     "activityBar.border": "#ebdbb2",
+    "activityBarTop.background": "#f9f5d7",
+    "activityBarTop.foreground": "#3c3836",
     "activityBarBadge.background": "#458588",
     "activityBarBadge.foreground": "#ebdbb2",
     // EDITOR GROUPS

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -919,6 +919,8 @@
     "activityBar.background": "#fbf1c7",
     "activityBar.foreground": "#3c3836",
     "activityBar.border": "#ebdbb2",
+    "activityBarTop.background": "#fbf1c7",
+    "activityBarTop.foreground": "#3c3836",
     "activityBarBadge.background": "#458588",
     "activityBarBadge.foreground": "#ebdbb2",
     // EDITOR GROUPS

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -919,6 +919,8 @@
     "activityBar.background": "#f2e5bc",
     "activityBar.foreground": "#3c3836",
     "activityBar.border": "#ebdbb2",
+    "activityBarTop.background": "#f2e5bc",
+    "activityBarTop.foreground": "#3c3836",
     "activityBarBadge.background": "#458588",
     "activityBarBadge.foreground": "#ebdbb2",
     // EDITOR GROUPS


### PR DESCRIPTION
Fixes default foreground colors for top and bottom Activity Bar positions.

From:
![before](https://github.com/user-attachments/assets/139e9161-7a6b-472a-a133-2728caf56811)

To:
![after](https://github.com/user-attachments/assets/26b94c98-d2ae-4f10-92b2-b68dacc65893)

