### PR TITLE
fix: remove transparent background for input warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "Christian Klaussner (https://github.com/klaussner)",
     "Anton Shpigunov (https://github.com/shpigunov)",
     "Piotr Więckiewicz (https://github.com/piotrwieckiewicz)",
-    "Andrew Malchuk (https://github.com/amalchuk)"
+    "Andrew Malchuk (https://github.com/amalchuk)",
+    "lmn451 (https://github.com/lmn451)"
   ],
   "publisher": "jdinhlife",
   "engines": {

--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -886,7 +886,7 @@
     "inputValidation.infoBorder": "#83a598",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#fabd2f",
-    "inputValidation.warningBackground": "#d7992180",
+    "inputValidation.warningBackground": "#d79921",
     "inputOption.activeBorder": "#ebdbb260",
     // SCROLL BAR
     "scrollbar.shadow": "#1d2021",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -886,7 +886,7 @@
     "inputValidation.infoBorder": "#83a598",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#fabd2f",
-    "inputValidation.warningBackground": "#d7992180",
+    "inputValidation.warningBackground": "#d79921",
     "inputOption.activeBorder": "#ebdbb260",
     // SCROLL BAR
     "scrollbar.shadow": "#282828",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -886,7 +886,7 @@
     "inputValidation.infoBorder": "#83a598",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#fabd2f",
-    "inputValidation.warningBackground": "#d7992180",
+    "inputValidation.warningBackground": "#d79921",
     "inputOption.activeBorder": "#ebdbb260",
     // SCROLL BAR
     "scrollbar.shadow": "#32302f",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -885,7 +885,7 @@
     "inputValidation.infoBorder": "#076678",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#b57614",
-    "inputValidation.warningBackground": "#d7992180",
+    "inputValidation.warningBackground": "#d79921",
     "inputOption.activeBorder": "#3c383660",
     // SCROLL BAR
     "scrollbar.shadow": "#f9f5d7",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -885,7 +885,7 @@
     "inputValidation.infoBorder": "#076678",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#b57614",
-    "inputValidation.warningBackground": "#d7992180",
+    "inputValidation.warningBackground": "#d79921",
     "inputOption.activeBorder": "#3c383660",
     // SCROLL BAR
     "scrollbar.shadow": "#fbf1c7",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -885,7 +885,7 @@
     "inputValidation.infoBorder": "#076678",
     "inputValidation.infoBackground": "#45858880",
     "inputValidation.warningBorder": "#b57614",
-    "inputValidation.warningBackground": "#d7992180",
+    "inputValidation.warningBackground": "#d79921",
     "inputOption.activeBorder": "#3c383660",
     // SCROLL BAR
     "scrollbar.shadow": "#f2e5bc",


### PR DESCRIPTION
This fix this specific issue 
![gruv](https://github.com/user-attachments/assets/8fc3fb3a-078a-422b-9b31-94ae73d6ac64)

and it is similar to this issue, https://github.com/jdinhify/vscode-theme-gruvbox/pull/99

Probably we should think about more robust solution and remove all 'transparentish' colors

@jdinhify wdyt?
