### PR TITLE
feat: add sticky scroll supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Special thank to [Pavel Pertsev](https://github.com/morhetz), the creator of [gr
 - [Anton Shpigunov](https://github.com/shpigunov)
 - [Piotr Więckiewicz](https://github.com/piotrwieckiewicz)
 - [Andrew Malchuk](https://github.com/amalchuk)
+- [Minseo Kim](https://github.com/kimminss0)
 
 Thanks for help to make the Gruvbox theme better.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "Christian Klaussner (https://github.com/klaussner)",
     "Anton Shpigunov (https://github.com/shpigunov)",
     "Piotr Więckiewicz (https://github.com/piotrwieckiewicz)",
-    "Andrew Malchuk (https://github.com/amalchuk)"
+    "Andrew Malchuk (https://github.com/amalchuk)",
+    "Minseo Kim (https://github.com/kimminss0)"
   ],
   "publisher": "jdinhlife",
   "engines": {

--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -988,6 +988,9 @@
     "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
+    // EDITOR - STICKY SCROLL
+    "editorStickyScroll.shadow":"#50494599",
+    "editorStickyScrollHover.background":"#3c383660",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -988,6 +988,9 @@
     "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
+    // EDITOR - STICKY SCROLL
+    "editorStickyScroll.shadow":"#50494599",
+    "editorStickyScrollHover.background":"#3c383660",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -988,6 +988,9 @@
     "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
+    // EDITOR - STICKY SCROLL
+    "editorStickyScroll.shadow":"#50494599",
+    "editorStickyScrollHover.background":"#3c383660",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#b8bb2630",
     "diffEditor.removedTextBackground": "#fb493430",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -987,6 +987,9 @@
     "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
+    // EDITOR - STICKY SCROLL
+    "editorStickyScroll.shadow":"#d5c4a199",
+    "editorStickyScrollHover.background":"#ebdbb260",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
     "diffEditor.removedTextBackground": "#9d000630",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -987,6 +987,9 @@
     "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
+    // EDITOR - STICKY SCROLL
+    "editorStickyScroll.shadow":"#d5c4a199",
+    "editorStickyScrollHover.background":"#ebdbb260",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
     "diffEditor.removedTextBackground": "#9d000630",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -987,6 +987,9 @@
     "editorBracketHighlight.foreground5": "#d79921",
     "editorBracketHighlight.foreground6": "#d65d0e",
     "editorBracketHighlight.unexpectedBracket.foreground": "#cc241d",
+    // EDITOR - STICKY SCROLL
+    "editorStickyScroll.shadow":"#d5c4a199",
+    "editorStickyScrollHover.background":"#ebdbb260",
     // DIFF EDITOR
     "diffEditor.insertedTextBackground": "#79740e30",
     "diffEditor.removedTextBackground": "#9d000630",


### PR DESCRIPTION
Closes #101

Added colors for sticky scroll:

- Shadow
- Background (on hover)

## Before

<img width="313" alt="스크린샷 2025-01-05 10 57 34" src="https://github.com/user-attachments/assets/86634ce6-492c-45d9-aea9-9af5852ec383" />

Gruvbox Light

<img width="320" alt="스크린샷 2025-01-05 10 57 43" src="https://github.com/user-attachments/assets/ef88bb26-7cb8-4d44-9127-152a888bb8ca" />

Gruvbox Light, hovered

<img width="321" alt="스크린샷 2025-01-05 10 58 11" src="https://github.com/user-attachments/assets/3a1cb205-7425-40d2-a7b0-b17011001041" />

Gruvbox Dark

<img width="315" alt="스크린샷 2025-01-05 10 58 20" src="https://github.com/user-attachments/assets/0f5c005e-f5ee-4150-9c61-02f1e0d45960" />

Gruvbox Dark, hovered

## After

<img width="284" alt="스크린샷 2025-01-05 10 59 23" src="https://github.com/user-attachments/assets/ae213431-491f-4229-9ed0-85402df89fec" />

Gruvbox Light

<img width="282" alt="스크린샷 2025-01-05 10 59 33" src="https://github.com/user-attachments/assets/73e47bf3-d99b-4eb9-813a-c75c428f9886" />

Gruvbox Light, hovered

<img width="282" alt="스크린샷 2025-01-05 10 58 54" src="https://github.com/user-attachments/assets/69dd83fe-686f-4d0d-a590-aa8b81994424" />

Gruvbox Dark

<img width="281" alt="스크린샷 2025-01-05 10 59 05" src="https://github.com/user-attachments/assets/4397705e-21a9-4c40-a109-9e7d2e7c85b5" />

Gruvbox Dark, hovered

