### PR TITLE
fix: Update input backgrounds to use solid colours

### DIFF
--- a/themes/gruvbox-dark-hard.json
+++ b/themes/gruvbox-dark-hard.json
@@ -841,7 +841,7 @@
     "dropdown.border": "#3c3836",
     "dropdown.foreground": "#ebdbb2",
     // INPUT
-    "input.background": "#ebdbb205",
+    "input.background": "#1d2021",
     "input.border": "#3c3836",
     "input.foreground": "#ebdbb2",
     "input.placeholderForeground": "#ebdbb260",

--- a/themes/gruvbox-dark-medium.json
+++ b/themes/gruvbox-dark-medium.json
@@ -841,7 +841,7 @@
     "dropdown.border": "#3c3836",
     "dropdown.foreground": "#ebdbb2",
     // INPUT
-    "input.background": "#ebdbb205",
+    "input.background": "#282828",
     "input.border": "#3c3836",
     "input.foreground": "#ebdbb2",
     "input.placeholderForeground": "#ebdbb260",

--- a/themes/gruvbox-dark-soft.json
+++ b/themes/gruvbox-dark-soft.json
@@ -841,7 +841,7 @@
     "dropdown.border": "#3c3836",
     "dropdown.foreground": "#ebdbb2",
     // INPUT
-    "input.background": "#ebdbb205",
+    "input.background": "#32302f",
     "input.border": "#3c3836",
     "input.foreground": "#ebdbb2",
     "input.placeholderForeground": "#ebdbb260",

--- a/themes/gruvbox-light-hard.json
+++ b/themes/gruvbox-light-hard.json
@@ -840,7 +840,7 @@
     "dropdown.border": "#ebdbb2",
     "dropdown.foreground": "#3c3836",
     // INPUT
-    "input.background": "#3c383605",
+    "input.background": "#f9f5d7",
     "input.border": "#ebdbb2",
     "input.foreground": "#3c3836",
     "input.placeholderForeground": "#3c383660",

--- a/themes/gruvbox-light-medium.json
+++ b/themes/gruvbox-light-medium.json
@@ -840,7 +840,7 @@
     "dropdown.border": "#ebdbb2",
     "dropdown.foreground": "#3c3836",
     // INPUT
-    "input.background": "#3c383605",
+    "input.background": "#fbf1c7",
     "input.border": "#ebdbb2",
     "input.foreground": "#3c3836",
     "input.placeholderForeground": "#3c383660",

--- a/themes/gruvbox-light-soft.json
+++ b/themes/gruvbox-light-soft.json
@@ -840,7 +840,7 @@
     "dropdown.border": "#ebdbb2",
     "dropdown.foreground": "#3c3836",
     // INPUT
-    "input.background": "#3c383605",
+    "input.background": "#f2e5bc",
     "input.border": "#ebdbb2",
     "input.foreground": "#3c3836",
     "input.placeholderForeground": "#3c383660",


### PR DESCRIPTION
To fix #110, sets `input.background` to the standard background colour used elsewhere in the theme. Note that this makes all the text input boxes across VS Code the same as the background colour, not just here. However, this is the same pattern that official themes such as "Default Light Modern" use, and has much better support across extensions (#108 is likely related for ex).

See below for before and after #110:

<img width="402" alt="Screenshot 2025-02-22 at 3 48 10 PM" src="https://github.com/user-attachments/assets/53703d44-52d1-46ee-a708-f64ff77410db" />
<img width="405" alt="Screenshot 2025-02-22 at 3 47 32 PM" src="https://github.com/user-attachments/assets/01470c08-fda5-46fd-994e-cbe048ef8f79" />

