### PR TITLE
fix: update git label contrast for readability

### DIFF
--- a/src/colors/base.ts
+++ b/src/colors/base.ts
@@ -237,6 +237,8 @@ export const getBaseColors = (scheme: ColorScheme, contrast: ColorContrast) => {
 		"gitDecoration.untrackedResourceForeground": green1,
 		"gitDecoration.ignoredResourceForeground": bg4,
 		"gitDecoration.conflictingResourceForeground": purple1,
+		"scmGraph.historyItemHoverLabelForeground": white,
+		"scmGraph.historyItemHoverDefaultLabelForeground": white,
 		// MENU BAR
 		"menu.border": bg1,
 		"menu.separatorBackground": bg1,


### PR DESCRIPTION
This commit improves readability of labels on git side panel for gruvbox-light variant themes.

Before:
<img width="294" alt="스크린샷 2025-03-03 13 07 48" src="https://github.com/user-attachments/assets/94e72289-2c77-4d1e-a840-1a2b91c1927a" />

After:
<img width="291" alt="스크린샷 2025-03-03 13 08 23" src="https://github.com/user-attachments/assets/d02c2b9c-2fdd-41ae-b3b5-8479b3b1db10" />
