### PR TITLE
 fix: Update input backgrounds to use solid colours

### DIFF
--- a/src/colors/base.ts
+++ b/src/colors/base.ts
@@ -47,7 +47,7 @@ export const getBaseColors = (scheme: ColorScheme, contrast: ColorContrast) => {
 		"dropdown.border": bg1,
 		"dropdown.foreground": fg1,
 		// INPUT
-		"input.background": withAlpha(fg1, 5),
+		"input.background": bg0,
 		"input.border": bg1,
 		"input.foreground": fg1,
 		"input.placeholderForeground": withAlpha(fg1, 96),


### PR DESCRIPTION
To fix #110, sets `input.background` to the standard background colour used elsewhere in the theme. Note that this makes all the text input boxes across VS Code the same as the background colour, not just here. However, this is the same pattern that official themes such as "Default Light Modern" use, and has much better support across extensions (#108 is likely related for ex).

See below for before and after #110:

<img width="402" alt="Screenshot 2025-02-22 at 3 48 10 PM" src="https://github.com/user-attachments/assets/53703d44-52d1-46ee-a708-f64ff77410db" />
<img width="405" alt="Screenshot 2025-02-22 at 3 47 32 PM" src="https://github.com/user-attachments/assets/01470c08-fda5-46fd-994e-cbe048ef8f79" />

