### PR TITLE
feat: add LaTeX support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { getGolangColors } from "./token-colors/languages/golang";
 import { getCucumberColors } from "./token-colors/languages/cucumber";
 import { getReasonMLColors } from "./token-colors/languages/reason-ml";
 import { getPowershellColors } from "./token-colors/languages/powershell";
+import { getLatexColors } from "./token-colors/languages/latex";
 import { getBaseTokenColors } from "./token-colors/base";
 import { getSemanticColors } from "./semantic-colors";
 import { getBaseColors } from "./colors/base";
@@ -56,6 +57,7 @@ const generateJson = (scheme: ColorScheme, contrast: ColorContrast) => {
 			...getCucumberColors(scheme, contrast),
 			...getReasonMLColors(scheme, contrast),
 			...getPowershellColors(scheme, contrast),
+			...getLatexColors(scheme, contrast),
 		],
 		colors: {
 			...getBaseColors(scheme, contrast),

--- a/src/token-colors/languages/latex.ts
+++ b/src/token-colors/languages/latex.ts
@@ -1,0 +1,53 @@
+import { allColors } from "../../shared";
+import { Getter } from "../types";
+
+export const getLatexColors: Getter = (scheme) => {
+    const { aqua2, red2, orange2, purple2 } = allColors[scheme];
+    return [
+        {
+            name: "LaTeX functions",
+            scope: [
+                "support.function.be.latex",
+                "support.function.general.tex",
+                "support.function.section.latex",
+                "support.function.textbf.latex",
+                "support.function.textit.latex",
+                "support.function.texttt.latex",
+                "support.function.emph.latex",
+                "support.function.url.latex",
+            ],
+            settings: {
+                foreground: red2,
+            }
+        },
+        {
+            name: "LaTeX text in math environment",
+            scope: [
+                "support.class.math.block.tex",
+                "support.class.math.block.environment.latex",
+            ],
+            settings: {
+                foreground: orange2,
+            }
+        },
+        {
+            name: "LaTeX preamble",
+            scope: [
+                "keyword.control.preamble.latex",
+                "keyword.control.include.latex",
+            ],
+            settings: {
+                foreground: purple2,
+            }
+        },
+        {
+            name: "LaTeX packages",
+            scope: [
+                "support.class.latex",
+            ],
+            settings: {
+                foreground: aqua2,
+            }
+        }
+    ];
+};

--- a/src/token-colors/languages/latex.ts
+++ b/src/token-colors/languages/latex.ts
@@ -2,52 +2,50 @@ import { allColors } from "../../shared";
 import { Getter } from "../types";
 
 export const getLatexColors: Getter = (scheme) => {
-    const { aqua2, red2, orange2, purple2 } = allColors[scheme];
-    return [
-        {
-            name: "LaTeX functions",
-            scope: [
-                "support.function.be.latex",
-                "support.function.general.tex",
-                "support.function.section.latex",
-                "support.function.textbf.latex",
-                "support.function.textit.latex",
-                "support.function.texttt.latex",
-                "support.function.emph.latex",
-                "support.function.url.latex",
-            ],
-            settings: {
-                foreground: red2,
-            }
-        },
-        {
-            name: "LaTeX text in math environment",
-            scope: [
-                "support.class.math.block.tex",
-                "support.class.math.block.environment.latex",
-            ],
-            settings: {
-                foreground: orange2,
-            }
-        },
-        {
-            name: "LaTeX preamble",
-            scope: [
-                "keyword.control.preamble.latex",
-                "keyword.control.include.latex",
-            ],
-            settings: {
-                foreground: purple2,
-            }
-        },
-        {
-            name: "LaTeX packages",
-            scope: [
-                "support.class.latex",
-            ],
-            settings: {
-                foreground: aqua2,
-            }
-        }
-    ];
+	const { aqua2, red2, orange2, purple2 } = allColors[scheme];
+	return [
+		{
+			name: "LaTeX functions",
+			scope: [
+				"support.function.be.latex",
+				"support.function.general.tex",
+				"support.function.section.latex",
+				"support.function.textbf.latex",
+				"support.function.textit.latex",
+				"support.function.texttt.latex",
+				"support.function.emph.latex",
+				"support.function.url.latex",
+			],
+			settings: {
+				foreground: red2,
+			},
+		},
+		{
+			name: "LaTeX text in math environment",
+			scope: [
+				"support.class.math.block.tex",
+				"support.class.math.block.environment.latex",
+			],
+			settings: {
+				foreground: orange2,
+			},
+		},
+		{
+			name: "LaTeX preamble",
+			scope: [
+				"keyword.control.preamble.latex",
+				"keyword.control.include.latex",
+			],
+			settings: {
+				foreground: purple2,
+			},
+		},
+		{
+			name: "LaTeX packages",
+			scope: ["support.class.latex"],
+			settings: {
+				foreground: aqua2,
+			},
+		},
+	];
 };


### PR DESCRIPTION
Finally closes #19. In this PR there is better support for various `support.function.*.latex` tokens in addition to those that I mentioned in the issue.