### PR TITLE
feat: add border for command panel and other widgets

### DIFF
--- a/src/colors/base.ts
+++ b/src/colors/base.ts
@@ -36,6 +36,7 @@ export const getBaseColors = (scheme: ColorScheme, contrast: ColorContrast) => {
 		focusBorder: bg1,
 		foreground: fg1,
 		"widget.shadow": withAlpha(bg0, 48),
+		"widget.border": bg1,
 		"selection.background": withAlpha(aqua1, 128),
 		errorForeground: red2,
 		"icon.foreground": fg1,


### PR DESCRIPTION
Hello @jdinhify! There is small fix to bring command palette and other editor widgets borders. I'm not sure if this behavior is intended or not. If it is intended, I will close this PR. Closes #133.

### Before
![image](https://github.com/user-attachments/assets/f4a88d6c-ec00-4c16-8047-fc3e3b05c0c5)

### After
![image](https://github.com/user-attachments/assets/aad7436a-82b1-4527-97a9-b4b0f1887b58)
